### PR TITLE
Tested package lock and unlock feature

### DIFF
--- a/features/lock_packages_on_client.feature
+++ b/features/lock_packages_on_client.feature
@@ -1,0 +1,47 @@
+# Copyright (c) 2010-2011 Novell, Inc.
+# Licensed under the terms of the MIT license.
+
+Feature: Lock packages on client
+
+  Scenario: Lock a package on the client
+    Given I am on the Systems overview page of this client
+      And I follow "Software" in the content area
+      And I follow "Lock"
+     When I check "hoag-dummy-1.1-2.1" in the list
+      And I click on "Request Lock"
+      And I run rhn_check on this client
+     Then I should see a "Packages has been requested for being locked." text
+      And "hoag-dummy-1.1-2.1" is locked on this client
+     Then I follow "Lock"
+     Then Package "hoag-dummy-1.1-2.1" is reported as locked
+
+  Scenario: Attempt to install a locked package on the client
+    Given I am on the Systems overview page of this client
+      And I follow "Software" in the content area
+      And I follow "Lock"
+      And Package "hoag-dummy-1.1-2.1" is reported as locked
+     Then I follow "Install"
+     When I check "hoag-dummy-1.1-2.1" in the list
+      And I click on "Install Selected Packages"
+      And I click on "Confirm"
+      And I run rhn_check on this client
+     Then I should see a "1 package install has been scheduled for" text
+     Then I follow "Events"
+      And I follow "History"
+      And I follow first "Package Install scheduled by admin"
+     Then The package scheduled is "hoag-dummy-1.1-2.1"
+      And The action status is "Failed"
+
+  Scenario: Unlock a package on the client
+    Given I am on the Systems overview page of this client
+      And I follow "Software" in the content area
+      And I follow "Lock"
+      And Package "hoag-dummy-1.1-2.1" is reported as locked
+     When I check "hoag-dummy-1.1-2.1" in the list
+      And I click on "Request Unlock"
+      And I run rhn_check on this client
+     Then I should see a "Packages has been requested for being unlocked." text
+      And "hoag-dummy-1.1-2.1" is unlocked on this client
+     Then I follow "Lock"
+     Then Package "hoag-dummy-1.1-2.1" is reported as unlocked
+

--- a/features/step_definitions/lock_packages_on_client.rb
+++ b/features/step_definitions/lock_packages_on_client.rb
@@ -1,0 +1,48 @@
+# Copyright (c) 2010-2011 Novell, Inc.
+# Licensed under the terms of the MIT license.
+
+Then /^"(.*?)" is locked on this client$/ do |pkg|
+  zypp_lock_file = "/etc/zypp/locks"
+  fail unless File.exists?(zypp_lock_file)
+
+  locks = read_zypp_lock_file(zypp_lock_file)
+  fail unless locks.find{|lock| lock['solvable_name'] == pkg}
+end
+
+Then /^Package "(.*?)" is reported as locked$/ do |pkg|
+  find(:xpath, "//a[text()='#{pkg}']")
+  locked_pkgs = all(:xpath, "//i[@class='fa fa-lock']/../a")
+
+  fail if locked_pkgs.empty?
+  fail unless locked_pkgs.find{|a| a.text =~ /^#{pkg}/}
+end
+
+Then /^"(.*?)" is unlocked on this client$/ do |pkg|
+  zypp_lock_file = "/etc/zypp/locks"
+  fail unless File.exists?(zypp_lock_file)
+
+  locks = read_zypp_lock_file(zypp_lock_file)
+  fail if locks.find{|lock| lock['solvable_name'] == pkg}
+end
+
+Then /^Package "(.*?)" is reported as unlocked$/ do |pkg|
+  find(:xpath, "//a[text()='#{pkg}']")
+  locked_pkgs = all(:xpath, "//i[@class='fa fa-lock']/../a")
+
+  fail if locked_pkgs.find{|a| a.text =~ /^#{pkg}/}
+end
+
+Then /^The package scheduled is "(.*?)"$/ do |pkg|
+  match = find(:xpath, "//li[@class='action-summary-package-nvre']")
+
+  fail unless match
+  fail unless match.text =~ /^#{pkg}/
+end
+
+Then /^The action status is "(.*?)"$/ do |status|
+  match = find(:xpath, "//td[@class='action-summary-details']")
+
+  fail unless match
+  fail unless match.text.include?("This action's status is: #{status}")
+end
+

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,7 +12,8 @@ require 'tmpdir'
 require 'base64'
 require 'capybara'
 require 'capybara/cucumber'
-require File.join(File.dirname(__FILE__), '/cobbler_test.rb')
+require File.join(File.dirname(__FILE__), 'cobbler_test')
+require File.join(File.dirname(__FILE__), 'zypp_lock_helper')
 
 browser = ( ENV['BROWSER'] ? ENV['BROWSER'].to_sym : nil ) || :firefox
 host = ENV['TESTHOST'] || 'andromeda.suse.de'

--- a/features/support/zypp_lock_helper.rb
+++ b/features/support/zypp_lock_helper.rb
@@ -1,0 +1,31 @@
+# Copyright (c) 2010-2014 Novell, Inc.
+# Licensed under the terms of the MIT license.
+
+#
+# features/support/zypp_lock_helper.rb
+#
+
+def read_zypp_lock_file(lock_file)
+  locks = []
+  lock  = {}
+
+  File.open(lock_file).each_line do |line|
+    next if line.start_with?("#")
+
+    line.strip!
+    if line.empty?
+      if !lock.keys.empty?
+        locks << lock
+        locl = {}
+      end
+    else
+      key, value = line.split(":", 2)
+      lock[key.strip] = value.strip
+    end
+  end
+
+  locks << lock unless lock.keys.empty?
+
+  locks
+end
+

--- a/run_sets/testsuite.yml
+++ b/run_sets/testsuite.yml
@@ -35,6 +35,7 @@
 - features/check_support_data.feature
 - features/check_registration.feature
 - features/erratapage.feature
+- features/lock_packages_on_client.feature
 - features/install_package.feature
 - features/install_errata-npn.feature
 - features/clone_channel-npn.feature


### PR DESCRIPTION
As per subject: testing package lock and unlock. The tests use the `hoag-dummy-1.1-2.1` package as target. This is done also by other features, hence I assumed this package is always available on the test instances.
