### PR TITLE
phantomjs support & remove obsolete code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem "cucumber","~> 1.3.0"
 gem "capybara","~> 2.1.0"
 gem "selenium-webdriver"
+gem 'poltergeist', :require => false
 gem "rubyzip"
 gem 'owasp_zap'

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -55,27 +55,15 @@ end
 #
 # Click on a link
 #
-When /^I follow "([^"]*)"$/ do |arg1|
-  link = find_link(debrand_string(arg1))
-  if link.nil?
-      sleep 1
-      $stderr.puts "ERROR - try again"
-      link = find_link(debrand_string(arg1))
-  end
-  link.click
+When /^I follow "([^"]*)"$/ do |text|
+  click_link(debrand_string(text))
 end
 
 #
 # Click on the first link
 #
-When /^I follow first "([^"]*)"$/ do |arg1|
-  link = find_link(debrand_string(arg1), :match => :first)
-  if link.nil?
-      sleep 1
-      $stderr.puts "ERROR - try again"
-      link = find_link(debrand_string(arg1))
-  end
-  link.click
+When /^I follow first "([^"]*)"$/ do |text|
+  click_link(debrand_string(text), :match => :first)
 end
 
 #

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -112,7 +112,7 @@ Capybara.run_server = false
 # screenshots
 After do |scenario|
   if scenario.failed?
-    encoded_img = page.driver.render_base64(:png)
+    encoded_img = page.driver.render_base64(:png, :full => true)
     embed("data:image/png;base64,#{encoded_img}", 'image/png')
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -77,7 +77,10 @@ when :phantomjs
   require 'capybara/poltergeist'
   Capybara.register_driver :poltergeist do |app|
     Capybara::Poltergeist::Driver.new(app,
-                                      :phantomjs_options => ['--debug=no', '--load-images=no', '--ignore-ssl-errors=yes', '--ssl-protocol=TLSv1'],
+                                      :phantomjs_options => ['--debug=no',
+                                                             '--ignore-ssl-errors=yes',
+                                                             '--ssl-protocol=TLSv1',
+                                                             '--web-security=false'],
                                       :debug => false)
   end
   Capybara.default_driver = :poltergeist


### PR DESCRIPTION
Implements support for running the testsuite using phantomjs, which is a WebKit based browser created specially for testing and has some advantages like being completely headless.

Also, remove support for other browsers that are obsolete tools and the code is not even working and remove unnecessary complexity, leaving only Firefox and PhantomJS.

@mseidl :+1: ?