### PR TITLE
Replacing bash ssh calls to the Net::SSH library.  

### DIFF
--- a/features/step_definitions/command_steps.rb
+++ b/features/step_definitions/command_steps.rb
@@ -2,9 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 When /^I execute ncc\-sync "([^"]*)"$/ do |arg1|
-  $command_output = ""
-  $command_output = `echo | ssh -l root -o StrictHostKeyChecking=no $TESTHOST mgr-ncc-sync #{arg1} 2>&1`
-  raise "Execute command failed: #{$!}: #{$command_output}" unless $?.success?
+  $command_output = sshcmd("mgr-ncc-sync #{arg1}")[:stdout]
 end
 
 When /^I execute mgr\-bootstrap "([^"]*)"$/ do |arg1|
@@ -13,10 +11,7 @@ When /^I execute mgr\-bootstrap "([^"]*)"$/ do |arg1|
   if arch != "x86_64"
     arch = "i586"
   end
-  $command_output = `echo | ssh -l root -o StrictHostKeyChecking=no $TESTHOST mgr-bootstrap --activation-keys=1-SUSE-PKG-#{arch} #{arg1} 2>&1`
-  if ! $?.success?
-    raise "Execute command failed: #{$!}: #{$command_output}"
-  end
+  $command_output = sshcmd("mgr-bootstrap --activation-keys=1-SUSE-PKG-#{arch} #{arg1}")[:stdout]
 end
 
 When /^I fetch "([^"]*)" from server$/ do |arg1|
@@ -34,54 +29,41 @@ When /^I execute "([^"]*)"$/ do |arg1|
 end
 
 When /^file "([^"]*)" exists on server$/ do |arg1|
-  $command_output = `echo | ssh -l root -o StrictHostKeyChecking=no $TESTHOST test -f "#{arg1}" 2>&1`
-  if ! $?.success?
-    raise "File #{arg1} does not exist on server"
-  end
+  sshcmd("test -f #{arg1}")
 end
 
 When /^file "([^"]*)" not exists on server$/ do |arg1|
-  $command_output = `echo | ssh -l root -o StrictHostKeyChecking=no $TESTHOST test -f "#{arg1}" 2>&1`
-  if $?.success?
-    raise "File #{arg1} exists on server"
-  end
+  sshcmd("test -f #{arg1}")
 end
 
 When /^file "([^"]*)" contains "([^"]*)"$/ do |arg1, arg2|
-  $command_output = `echo | ssh -l root -o StrictHostKeyChecking=no $TESTHOST grep "#{arg2}" "#{arg1}" 2>&1`
-  if ! $?.success?
-    $stderr.write("-----\n#{$command_output}\n-----\n")
+  output = sshcmd("grep #{arg2} #{arg1}", ignore_err:  true)
+  unless output[:stderr].empty?
+    $stderr.write("-----\n#{output[:stderr]}\n-----\n")
     raise "#{arg2} not found in File #{arg1}"
   end
 end
 
 When /^I check the tomcat logs for errors$/ do
-  $command_output = `echo | ssh -l root -o StrictHostKeyChecking=no $TESTHOST grep ERROR /var/log/tomcat6/catalina.out 2>&1`
-  $command_output.each_line() do |line|
+  output = sshcmd("grep ERROR /var/log/tomcat6/catalina.out", ignore_err: true)[:stdout]
+  output.each_line() do |line|
     puts line
   end
 end
 
 When /^I check the tomcat logs for NullPointerExceptions$/ do
-  $command_output = `echo | ssh -l root -o StrictHostKeyChecking=no $TESTHOST grep -n1 NullPointer /var/log/tomcat6/catalina.out 2>&1`
-  $command_output.each_line() do |line|
+  output = sshcmd("grep -n1 NullPointer /var/log/tomcat6/catalina.out", ignore_err: true)[:stdout]
+  output.each_line() do |line|
     puts line
   end
 end
 
 Then /^I restart the spacewalk service$/ do
-  $command_output = ""
-  $command_output = `echo | ssh -l root -o StrictHostKeyChecking=no $TESTHOST spacewalk-service restart 2>&1`
-  if ! $?.success?
-    raise "Execute command failed: #{$!}: #{$command_output}"
-  end
+  sshcmd("spacewalk-service restart")
 end
 
 Then /^I execute spacewalk-debug on the server$/ do
-  $command_output = `echo | ssh -l root -o StrictHostKeyChecking=no $TESTHOST spacewalk-debug 2>&1`
-  if ! $?.success?
-    raise "Execute command failed: #{$!}: #{$command_output}"
-  end
+  sshcmd("spacewalk-debug")
 end
 
 When /^I copy "([^"]*)"$/ do |arg1|
@@ -109,20 +91,15 @@ Then /^the pxe-default-profile should be disabled$/ do
 end
 
 Then /^the cobbler report contains "([^"]*)"$/ do |arg1|
-  $command_output = `echo | ssh -l root -o StrictHostKeyChecking=no $TESTHOST cobbler system report --name "#{$myhostname}:1" 2>&1`
-  if ! $?.success?
-    raise "Execute command failed: #{$!}: #{$command_output}"
-  end
-  if ! $command_output.include?(arg1)
-    raise "Not found: #{$command_output}"
+  output = sshcmd("cobbler system report --name #{$myhostname}:1", ignore_err: true)[:stdout]
+  unless output.include?(arg1)
+    raise "Not found: #{output}"
   end
 end
 
 Then /^I clean the search index on the server$/ do
-  $command_output = `echo | ssh -l root -o StrictHostKeyChecking=no $TESTHOST /usr/sbin/rcrhn-search cleanindex 2>&1`
-  if ! $?.success?
-    raise "Execute command failed: #{$!}: #{$command_output}"
-  end
+  output = sshcmd("/usr/sbin/rcrhn-search cleanindex", ignore_err: true)
+  fail if output[:stdout].include?('ERROR')
 end
 
 When /^I execute spacewalk\-channel and pass "([^"]*)"$/ do |arg1|

--- a/features/step_definitions/setup_wizard.rb
+++ b/features/step_definitions/setup_wizard.rb
@@ -41,10 +41,10 @@ When /^I wait until it has finished$/ do
 end
 
 When /^I verify the products were added$/ do 
-   $sshout = `echo | ssh -l root -o StrictHostKeyChecking=no $TESTHOST mgr-ncc-sync -l` 
-   fail if not $sshout.include? '[P] sles11-sp3-vmware-pool-x86_64'
-   fail if not $sshout.include? '[P] sle11-sp2-webyast-1.3-pool-x86_64-vmware-sp3'
-   fail if not $sshout.include? '[P] sle11-sp2-webyast-1.3-updates-x86_64-vmware-sp3'
+  output = sshcmd('mgr-ncc-sync -l', ignore_err: true)
+   fail if not output[:stdout].include? '[P] sles11-sp3-vmware-pool-x86_64'
+   fail if not output[:stdout].include? '[P] sle11-sp2-webyast-1.3-pool-x86_64-vmware-sp3'
+   fail if not output[:stdout].include? '[P] sle11-sp2-webyast-1.3-updates-x86_64-vmware-sp3'
 end
 
 When(/^I click the channel list of product "(.*?)" for the "(.*?)" architecture$/) do |product, architecture|

--- a/features/support/ssh.rb
+++ b/features/support/ssh.rb
@@ -1,0 +1,20 @@
+require 'net/ssh'
+require 'stringio'
+
+def sshcmd(command, host: ENV['TESTHOST'], user: 'root', ignore_err: false)
+  #Execute a command on the remote server
+  #Not passing :password uses systems keys for auth
+  out = StringIO.new
+  err = StringIO.new
+  Net::SSH.start(host, user) do |ssh|
+    ssh.exec!(command) do |chan, str, data|
+      out << data if str == :stdout
+      err << data if str == :stderr
+    end
+  end
+  if err.string.empty? || ignore_err
+    results = { stdout: out.string, stderr: err.string }
+  else
+    raise "Execute command failed #{command}: #{err.string}"
+  end
+end


### PR DESCRIPTION
I tested this and it works.  This replaces all the `ssh ....` with net::ssh library.  I've run the whole test suite against this branch and everything passes.  
