### PR TITLE
Let Cuke quit on first failure

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -130,6 +130,9 @@ After do |scenario|
       page.driver.render(path)
       embed("data:image/png;base64,#{Base64.encode64(File.read(path))}", 'image/png')
     end
+    if ENV['EXIT_ON_FAILURE']
+      Cucumber.wants_to_quit = true
+    end
   end
 end
 


### PR DESCRIPTION
Sometimes you need to just stop when cuke got first error, because the next errors often might make no sense as being based on the success of the scenario that just failed.

Usage:
`export TERMINATE=yes`