### PR TITLE
Various testsuite HEAD fixes

### DIFF
--- a/features/step_definitions/content_steps.rb
+++ b/features/step_definitions/content_steps.rb
@@ -81,7 +81,21 @@ Then /^I should see a "([^"]*)" link in "([^"]*)" "([^"]*)"$/ do |arg1, arg2, ar
   fail if not page.has_xpath?("//#{arg2}[@id='#{arg3}' or @class='#{arg3}']/a[text()='#{debrand_string(arg1)}']")
 end
 
-Then /^I should see a "([^"]*)" link in the (.+)$/ do |arg1, arg2|
+Then /^I should see a "([^"]*)" link in the table (.*) column$/ do |link, column|
+  idx = ['first', 'second', 'third', 'fourth'].index(column)
+  unless idx
+    # try column by name
+    # unquote if neeeded
+    colname = column.gsub(/\A['"]+|['"]+\Z/, '')
+    cols = page.all(:xpath, '//table//thead/tr[1]/th').map(&:text)
+    idx = cols.index(colname)
+  end
+  fail("Unknown column '#{column}'") unless idx
+  #find(:xpath, "//table//thead//tr/td[#{idx + 1}]/a[text()='#{link}']")
+  fail unless page.has_xpath?("//table//tr/td[#{idx + 1}]//a[text()='#{link}']")
+end
+
+Then /^I should see a "([^"]*)" link in the (left menu|tab bar|tabs|content area)$/ do |arg1, arg2|
   tag = case arg2
   when /left menu/ then "aside"
   when /tab bar|tabs/ then "header"

--- a/features/step_definitions/xmlrpc_system_steps.rb
+++ b/features/step_definitions/xmlrpc_system_steps.rb
@@ -15,12 +15,12 @@ When /^I call system\.listSystems\(\), I should get a list of them\.$/ do
 end
 
 When /^I check a sysinfo by a number of XML\-RPC calls, it just works\. :\-\)$/ do
-  fail if (rabbit == nil or !systest.getSysInfo(rabbit))
+  fail unless rabbit
+  systest.getSysInfo(rabbit)
 end
 
 When /^I call system\.createSystemRecord\(\) with sysName "([^"]*)", ksLabel "([^"]*)", ip "([^"]*)", mac "([^"]*)"$/ do |sysName, ksLabel, ip, mac|
-  result = systest.createSystemRecord(sysName, ksLabel, ip, mac)
-  fail if !result
+  systest.createSystemRecord(sysName, ksLabel, ip, mac)
 end
 
 Then /^there is a system record in cobbler named "([^"]*)"$/ do |sysName|

--- a/features/step_definitions/xmlrpc_system_steps.rb
+++ b/features/step_definitions/xmlrpc_system_steps.rb
@@ -2,14 +2,13 @@ systest = XMLRPCSystemTest.new(ENV['TESTHOST'])
 servers = []
 rabbit = nil
 
-
 Given /^I am logged in via XML\-RPC\/system as user "([^"]*)" and password "([^"]*)"$/ do |luser, password|
   systest.login(luser, password)
 end
 
 When /^I call system\.listSystems\(\), I should get a list of them\.$/ do
   # This also assumes the test is called *after* the regular test.
-  servers = systest.listSystems()
+  servers = systest.listSystems
   fail if servers.length < 1
   rabbit = servers[0]
 end
@@ -24,15 +23,15 @@ When /^I call system\.createSystemRecord\(\) with sysName "([^"]*)", ksLabel "([
 end
 
 Then /^there is a system record in cobbler named "([^"]*)"$/ do |sysName|
-  ct = CobblerTest.new()
-  if !ct.is_running
-    raise "cobblerd is not running"
+  ct = CobblerTest.new
+  unless ct.is_running
+    fail 'cobblerd is not running'
   end
-  if !ct.system_exists(sysName)
-    raise "cobbler system record does not exist: " + sysName
+  unless ct.system_exists(sysName)
+    fail 'cobbler system record does not exist: ' + sysName
   end
 end
 
 Then /^I logout from XML\-RPC\/system\.$/ do
-  systest.logout()
+  systest.logout
 end

--- a/features/support/xmlrpc_system.rb
+++ b/features/support/xmlrpc_system.rb
@@ -3,25 +3,24 @@ $LOAD_PATH << File.dirname(__FILE__) # For Ruby 1.8
 
 require 'xmlrpctest'
 
-
 class XMLRPCSystemTest < XMLRPCBaseTest
-  def listSystems()
-    @connection.call("system.listSystems", @sid) || []
+  def listSystems
+    @connection.call('system.listSystems', @sid) || []
   end
 
   # Get the list of latest installable packages for a given system.
   def listAllInstallablePackages(server)
-    @connection.call("system.listAllInstallablePackages", @sid, server) || []
+    @connection.call('system.listAllInstallablePackages', @sid, server) || []
   end
 
   # Get the list of latest upgradable packages for a given system.
   def listLatestUpgradablePackages(server)
-    @connection.call("system.listLatestUpgradablePackages", @sid, server) || []
+    @connection.call('system.listLatestUpgradablePackages', @sid, server) || []
   end
 
   # List the installed packages for a given system.
   def listPackages(server)
-    @connection.call("system.listPackages", @sid, server) || []
+    @connection.call('system.listPackages', @sid, server) || []
   end
 
   # Go wild...
@@ -29,14 +28,14 @@ class XMLRPCSystemTest < XMLRPCBaseTest
   # We just do it all at once instead.
   def getSysInfo(server)
     serverId = server['id']
-    connPath = @connection.call("system.getConnectionPath", @sid, serverId)
+    connPath = @connection.call('system.getConnectionPath', @sid, serverId)
     puts connPath
   end
 
   # Create a cobbler system record for a system that is not registered
   def createSystemRecord(sysName, ksLabel, ip, mac)
-    netdev = {"ip"=>ip, "mac"=>mac, "name"=>"eth0"}
+    netdev = { 'ip' => ip, 'mac' => mac, 'name' => 'eth0' }
     netdevs = [netdev]
-    @connection.call("system.createSystemRecord", @sid, sysName, ksLabel, "", "", netdevs)
+    @connection.call('system.createSystemRecord', @sid, sysName, ksLabel, '', '', netdevs)
   end
 end

--- a/features/support/xmlrpc_system.rb
+++ b/features/support/xmlrpc_system.rb
@@ -6,22 +6,22 @@ require 'xmlrpctest'
 
 class XMLRPCSystemTest < XMLRPCBaseTest
   def listSystems()
-    return (@connection.call("system.listSystems", @sid) || [])
+    @connection.call("system.listSystems", @sid) || []
   end
 
   # Get the list of latest installable packages for a given system.
   def listAllInstallablePackages(server)
-    return (@connection.call("system.listAllInstallablePackages", @sid, server) || [])
+    @connection.call("system.listAllInstallablePackages", @sid, server) || []
   end
 
   # Get the list of latest upgradable packages for a given system.
   def listLatestUpgradablePackages(server)
-    return (@connection.call("system.listLatestUpgradablePackages", @sid, server) || [])
+    @connection.call("system.listLatestUpgradablePackages", @sid, server) || []
   end
 
   # List the installed packages for a given system.
   def listPackages(server)
-    return (@connection.call("system.listPackages", @sid, server) || [])
+    @connection.call("system.listPackages", @sid, server) || []
   end
 
   # Go wild...
@@ -29,28 +29,14 @@ class XMLRPCSystemTest < XMLRPCBaseTest
   # We just do it all at once instead.
   def getSysInfo(server)
     serverId = server['id']
-    begin
-      connPath = @connection.call("system.getConnectionPath", @sid, serverId)
-      puts connPath
-    rescue Exception => ex
-      puts "Ouch: " + ex
-      return false
-    end
-
-    return true
+    connPath = @connection.call("system.getConnectionPath", @sid, serverId)
+    puts connPath
   end
 
   # Create a cobbler system record for a system that is not registered
   def createSystemRecord(sysName, ksLabel, ip, mac)
     netdev = {"ip"=>ip, "mac"=>mac, "name"=>"eth0"}
     netdevs = [netdev]
-    begin
-      ret = @connection.call("system.createSystemRecord", @sid, sysName, ksLabel, "", "", netdevs)
-    rescue Exception => ex
-      puts "Ouch: " + ex
-      return false
-    end
-
-    return true
+    @connection.call("system.createSystemRecord", @sid, sysName, ksLabel, "", "", netdevs)
   end
 end

--- a/features/support/xmlrpc_system.rb
+++ b/features/support/xmlrpc_system.rb
@@ -1,7 +1,4 @@
-File.expand_path(__FILE__)           # For Ruby 1.9.2+
-$LOAD_PATH << File.dirname(__FILE__) # For Ruby 1.8
-
-require 'xmlrpctest'
+require_relative 'xmlrpctest'
 
 class XMLRPCSystemTest < XMLRPCBaseTest
   def listSystems

--- a/features/users.feature
+++ b/features/users.feature
@@ -14,6 +14,5 @@ Feature: Check users page/tab
         And I should see a "Active" link in the left menu
         And I should see a "Deactivated" link in the left menu
         And I should see a "All" link in the left menu
-        #And I should see a "admin" link in "td" "first-column "
-        And I should see 3 "admin" links
+	And I should see a "admin" link in the table first column
         And I should see a "Download CSV" link


### PR DESCRIPTION
Replace the "test that there are 3 admins links somewhere in the page" with
the specific user page assertion that one admin link is in the table.

For that, we add table step definition to test for links in a more natural
way.