### PR TITLE
Salt smoke test

### DIFF
--- a/features/salt.feature
+++ b/features/salt.feature
@@ -1,0 +1,17 @@
+# Copyright (c) 2015 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Check if SaltStack Master is configured and running
+  In order to operate SUSE Manager
+  As the admin user
+  I want to check if SaltStack Master is installed and running
+
+  Scenario: Check SaltStack Master is installed
+    When I get a content of a file "/etc/salt/master"
+    Then it should contain "rest_cherrypy:" text
+    And it should contain "port: 9080" text
+    And it should contain "external_auth:" text
+
+  Scenario: Check SaltStack Master is properly configured
+    When I issue command "ss -nta | grep 9080"
+    Then it should contain "127.0.0.1:9080" text

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -1,0 +1,9 @@
+# Copyright 2015 SUSE LLC
+
+When(/^I get a content of a file "(.*?)"$/) do |filename|
+  $output = sshcmd("cat #{filename}")
+end
+
+Then(/^it should contain "(.*?)" text$/) do |content|
+  fail if not $output[:stdout].include? content
+end


### PR DESCRIPTION
Adds minimal look at Salt Master on the target machine.

```
# cucumber features/salt.feature
# Copyright (c) 2015 SUSE LLC
# Licensed under the terms of the MIT license.
Feature: Check if SaltStack Master is configured and running
  In order to operate SUSE Manager
  As the admin user
  I want to check if SaltStack Master is installed and running

  Scenario: Check SaltStack Master is installed       # features/salt.feature:9
    When I get a content of a file "/etc/salt/master" # features/step_definitions/salt_steps.rb:3
      This scenario ran at: 2015-07-28 11:10:04 +0000
    Then it should contain "rest_cherrypy:" text      # features/step_definitions/salt_steps.rb:7
    And it should contain "port: 9080" text           # features/step_definitions/salt_steps.rb:7
    And it should contain "external_auth:" text       # features/step_definitions/salt_steps.rb:7

  Scenario: Check SaltStack Master is properly configured # features/salt.feature:15
    When I issue command "ss -nta | grep 9080"            # features/step_definitions/smdba_steps.rb:115
      This scenario ran at: 2015-07-28 11:10:04 +0000
    Then it should contain "127.0.0.1:9080" text          # features/step_definitions/salt_steps.rb:7

2 scenarios (2 passed)
6 steps (6 passed)
0m0.317s

```