### PR TITLE
Salt minion smoketests

### DIFF
--- a/features/salt.feature
+++ b/features/salt.feature
@@ -15,3 +15,25 @@ Feature: Check if SaltStack Master is configured and running
   Scenario: Check SaltStack Master is properly configured
     When I issue command "ss -nta | grep 9080"
     Then it should contain "127.0.0.1:9080" text
+
+  Scenario: Check SaltStack Minion is running
+    When I issue local command "rcsalt-minion status | grep Active"
+    Then it should contain "active (running) since" text
+
+  Scenario: Check SaltStack Minion can be registered
+    When I issue command "salt-key --list unaccepted"
+    Then it should contain testsuite hostname
+    When I issue command "yes | salt-key -A"
+    And when I issue command "salt-key --list accepted"
+    Then it should contain testsuite hostname
+
+  Scenario: Check if SaltStack Minion communicates with the Master
+    When I ping client machine from the Master
+    Then it should contain testsuite hostname
+    When I get OS information of the client machine from the Master
+    Then it should contain "SLES" text
+
+  Scenario: Cleaning up for the general testsuite
+    When I delete key of the testsuite hostname
+    And when I issue command "salt-key --list unaccepted"
+    Then it should contain testsuite hostname

--- a/features/salt.feature
+++ b/features/salt.feature
@@ -13,8 +13,9 @@ Feature: Check if SaltStack Master is configured and running
     And it should contain "external_auth:" text
 
   Scenario: Check SaltStack Master is properly configured
-    When I issue command "ss -nta | grep 9080"
-    Then it should contain "127.0.0.1:9080" text
+    Then the Salt rest-api should be listening on local port 9080
+    And the salt-master should be listening on public port 4505
+    And the salt-master should be listening on public port 4506
 
   Scenario: Check SaltStack Minion is running
     When I issue local command "rcsalt-minion status | grep Active"

--- a/features/salt.feature
+++ b/features/salt.feature
@@ -35,6 +35,6 @@ Feature: Check if SaltStack Master is configured and running
     Then it should contain "SLES" text
 
   Scenario: Cleaning up for the general testsuite
-    When I delete key of the testsuite hostname
+    When I delete key of this client
     And when I issue command "salt-key --list unaccepted"
     Then it should contain testsuite hostname

--- a/features/salt.feature
+++ b/features/salt.feature
@@ -7,6 +7,7 @@ Feature: Check if SaltStack Master is configured and running
   I want to check if SaltStack Master is installed and running
 
   Scenario: Check SaltStack Master is installed
+    Given this client hostname
     When I get a content of a file "/etc/salt/master"
     Then it should contain "rest_cherrypy:" text
     And it should contain "port: 9080" text
@@ -18,23 +19,26 @@ Feature: Check if SaltStack Master is configured and running
     And the salt-master should be listening on public port 4506
 
   Scenario: Check SaltStack Minion is running
-    When I issue local command "rcsalt-minion status | grep Active"
-    Then it should contain "active (running) since" text
+    When I remove possible Salt Master key "/etc/salt/pki/minion/minion_master.pub"
+    And when I restart Salt Minion
+    Then the Salt Minion should be running
 
   Scenario: Check SaltStack Minion can be registered
-    When I issue command "salt-key --list unaccepted"
-    Then it should contain testsuite hostname
-    When I issue command "yes | salt-key -A"
-    And when I issue command "salt-key --list accepted"
-    Then it should contain testsuite hostname
+    Given this client hostname
+    When I list unaccepted keys at Salt Master
+    Then the list of the keys should contain this client hostname
+    When I accept all Salt unaccepted keys
+    When I list accepted keys at Salt Master
+    Then the list of the keys should contain this client hostname
 
   Scenario: Check if SaltStack Minion communicates with the Master
-    When I ping client machine from the Master
-    Then it should contain testsuite hostname
+    Given this client hostname
+    Then the Salt Minion should be running
     When I get OS information of the client machine from the Master
     Then it should contain "SLES" text
 
   Scenario: Cleaning up for the general testsuite
+    Given this client hostname
     When I delete key of this client
-    And when I issue command "salt-key --list unaccepted"
+    When I list unaccepted keys at Salt Master
     Then it should contain testsuite hostname

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -34,3 +34,11 @@ end
 Then(/^it should contain testsuite hostname$/) do
   fail if not $output[:stdout].include? $testsuite_hostname
 end
+
+Then(/^the Salt rest\-api should be listening on local port (\d+)$/) do |port|
+  fail if not sshcmd("ss -nta | grep #{port}")[:stdout].include? "127.0.0.1:#{port}"
+end
+
+Then(/^the salt\-master should be listening on public port (\d+)$/) do |port|
+  fail if not sshcmd("ss -nta | grep #{port}")[:stdout].include? "*:#{port}"
+end

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -1,9 +1,36 @@
 # Copyright 2015 SUSE LLC
+$testsuite_hostname = `hostname -f`.chomp
 
 When(/^I get a content of a file "(.*?)"$/) do |filename|
   $output = sshcmd("cat #{filename}")
 end
 
+When(/^I issue local command "(.*?)"$/) do |command|
+  $local_output = `#{command}`
+  $output = {:stdout => $local_output}
+end
+
+When(/^I delete key of the testsuite hostname$/) do
+  sshcmd("yes | salt-key -d #{$testsuite_hostname}")
+  `rcsalt-minion restart`
+
+  puts "Waiting for the longest RSA key re-issue (10 secons)"
+  # Longest key re-issue is 10 seconds. We sleep here 15.
+  sleep(15)
+end
+
+When(/^I ping client machine from the Master$/) do
+  $output = sshcmd("salt #{$testsuite_hostname} test.ping")
+end
+
+When(/^I get OS information of the client machine from the Master$/) do
+  $output = sshcmd("salt #{$testsuite_hostname} grains.get os")
+end
+
 Then(/^it should contain "(.*?)" text$/) do |content|
   fail if not $output[:stdout].include? content
+end
+
+Then(/^it should contain testsuite hostname$/) do
+  fail if not $output[:stdout].include? $testsuite_hostname
 end

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -10,7 +10,7 @@ When(/^I issue local command "(.*?)"$/) do |command|
   $output = {:stdout => $local_output}
 end
 
-When(/^I delete key of the testsuite hostname$/) do
+When(/^I delete key of this client$/) do
   sshcmd("yes | salt-key -d #{$testsuite_hostname}")
   `rcsalt-minion restart`
 

--- a/run_sets/testsuite.yml
+++ b/run_sets/testsuite.yml
@@ -1,4 +1,5 @@
 --- # List of features for a full test run
+- features/salt.feature
 - features/init_user_create.feature
 - features/setup_proxy.feature
 - features/running.feature


### PR DESCRIPTION
Add basic Salt Minion smoke test and activate it at the beginning.
Note: this test also cleaning up itself (i.e. un-registers the client key and restarts the minion) for the future tests.