### PR TITLE
Test for the download endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gem 'poltergeist', :require => false
 gem "rubyzip"
 gem 'owasp_zap'
 gem 'net-ssh'
+gem 'jwt'

--- a/features/download_endpoint.feature
+++ b/features/download_endpoint.feature
@@ -1,0 +1,14 @@
+Feature: Endpoint to download packages
+  In Order distribute software to the clients
+  As an authorized user
+  I want to download packages from the channels
+
+  Scenario: user without token
+    Given I try download "virgo-dummy-2.0-1.1.noarch.rpm" from channel "sles11-sp3-updates-x86_64-channel"
+    Then the download should get a 403 response
+
+  Scenario: user with a valid token for the org
+    Given I have a valid token for organization "1"
+    Then I try download "virgo-dummy-2.0-1.1.noarch.rpm" from channel "sles11-sp3-updates-x86_64-channel"
+    Then the download should get no error
+

--- a/features/step_definitions/download_endpoint_steps.rb
+++ b/features/step_definitions/download_endpoint_steps.rb
@@ -1,0 +1,28 @@
+require 'open-uri'
+require 'tempfile'
+
+Given(/^I try download "([^"]*)" from channel "([^"]*)"$/) do |rpm, channel|
+  url = "#{Capybara.app_host}/rhn/manager/download/#{channel}/getPackage/#{rpm}"
+  if @token
+    url = "#{url}?#{@token}"
+  end
+  puts url
+  Tempfile.open(rpm) do |tmpfile|
+    @download_path = tmpfile.path
+    begin
+      open(url) do |urlfile|
+        tmpfile.write(urlfile.read)
+      end
+    rescue OpenURI::HTTPError => e
+      @download_error = e
+    end
+  end
+end
+
+Then(/^the download should get a (\d+) response$/) do |code|
+  assert_equal(code.to_i, @download_error.io.status[0].to_i)
+end
+
+Then(/^the download should get no error$/) do
+  assert_nil(@download_error)
+end

--- a/features/step_definitions/download_token_steps.rb
+++ b/features/step_definitions/download_token_steps.rb
@@ -1,0 +1,20 @@
+require 'jwt'
+
+def token(secret, org, channels)
+  payload = { org: org }
+  if channels && !channels.empty?
+    payload.merge!(onlyChannels: channels)
+  end
+  puts secret
+  JWT.encode payload, [secret].pack('H*').bytes.to_a.pack('c*'), 'HS256'
+end
+
+def server_secret
+  rhnconf = sshcmd('cat /etc/rhn/rhn.conf')[:stdout]
+  data = /server.secret_key\s*=\s*(\h+)$/.match(rhnconf)
+  return data[1].strip
+end
+
+Given(/^I have a valid token for organization "([^"]*)"$/) do |arg1|
+  @token = token(server_secret, 1, nil)
+end

--- a/run_sets/testsuite.yml
+++ b/run_sets/testsuite.yml
@@ -70,6 +70,7 @@
 - features/salt.feature
 - features/salt_minions_page.feature
 - features/salt_minion_details.feature
+- features/download_endpoint.feature
 # End salt related features
 - features/change_password.feature
 - features/spacewalk-debug.feature


### PR DESCRIPTION
Requires: https://github.com/SUSE/spacewalk/pull/401 because it uses simple signed tokens using the server secret directly without any extra key derivation.
