### PR TITLE
test for disabled local repositories after registration (bnc971788)

### DIFF
--- a/features/salt_minions_page.feature
+++ b/features/salt_minions_page.feature
@@ -47,3 +47,7 @@ Feature: Explore the Minions page
     Given that the master can reach this client
     When I get OS information of the Minion from the Master
     Then it should contain a "SLES" text
+
+  Scenario: The minion got all local repositories disabled
+    Given that this minion is registered in Spacewalk
+    Then all local repositories are disabled

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -211,3 +211,22 @@ And(/^this minion is not registered in Spacewalk$/) do
   @rpc.deleteSystem(sid) if sid
   refute_includes(@rpc.listSystems.map {|s| s['id']}, $myhostname)
 end
+
+Given(/^that this minion is registered in Spacewalk$/) do
+  @rpc = XMLRPCSystemTest.new(ENV['TESTHOST'])
+  @rpc.login('admin', 'admin')
+  assert_includes(@rpc.listSystems.map {|s| s['name']}, $myhostname)
+end
+
+Then(/^all local repositories are disabled$/) do
+  Nokogiri::XML(`zypper -x lr`)
+    .xpath('//repo-list')
+    .children
+    .select { |node| node.is_a?(Nokogiri::XML::Element) }
+    .select { |element| element.name == 'repo' }
+    .reject { |repo| repo[:alias].include?('susemanager:') }
+    .map do |repo|
+      assert_equal('0', repo[:enabled],
+                   "repo #{repo[:alias]} should be disabled")
+    end
+end


### PR DESCRIPTION
This test checks that after minion registration, all local repositories are disabled (repos not starting with susemanager:)

https://bugzilla.suse.com/show_bug.cgi?id=971788