### PR TITLE
Add test for minion default channel

### DIFF
--- a/features/salt_minion_details.feature
+++ b/features/salt_minion_details.feature
@@ -19,7 +19,7 @@ Feature: Verify the minion registration
     Then I should see a "aaa_base" text
     And I should see a "aaa_base-extras" text
 
-  Scenario: Accepted minion have a base channel
+  Scenario: Accepted minion has a base channel
     Given that this minion is registered in Spacewalk
     And I follow this client link
     And I follow "Software"

--- a/features/salt_minion_details.feature
+++ b/features/salt_minion_details.feature
@@ -3,7 +3,10 @@
 
 Feature: Verify the minion registration
   In order to validate the completeness of minion registration
-  I want to see minion details and installed packages
+  I want to see minion base channel, minion details and installed packages
+
+  Background:
+    Given I am authorized as "testing" with password "testing"
 
   Scenario: Check for the Salt entitlement
     Given I am on the Systems overview page of this client
@@ -15,3 +18,10 @@ Feature: Verify the minion registration
     And I follow "List / Remove"
     Then I should see a "aaa_base" text
     And I should see a "aaa_base-extras" text
+
+  Scenario: Accepted minion have a base channel
+    Given that this minion is registered in Spacewalk
+    And I follow this client link
+    And I follow "Software"
+    And I follow "Software Channels"
+    Then this minion should have a Base channel set

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -207,6 +207,10 @@ Then(/^salt\-master should be listening on public port (\d+)$/) do |port|
   assert_match(/\*:#{port}/, output[:stdout])
 end
 
+Then(/^this minion should have a Base channel set$/) do
+  step %(I should not see a "This system has no Base Software Channel. You can select a Base Channel from the list below." text)
+end
+
 And(/^this minion is not registered in Spacewalk$/) do
   @rpc = XMLRPCSystemTest.new(ENV['TESTHOST'])
   @rpc.login('admin', 'admin')


### PR DESCRIPTION
A minion should always have a default base channel associated.
https://github.com/SUSE/spacewalk/pull/715