### PR TITLE
Prevent multiple login failures because "Background" steps

### DIFF
--- a/features/salt_minion_details.feature
+++ b/features/salt_minion_details.feature
@@ -5,9 +5,6 @@ Feature: Verify the minion registration
   In order to validate the completeness of minion registration
   I want to see minion base channel, minion details and installed packages
 
-  Background:
-    Given I am authorized as "testing" with password "testing"
-
   Scenario: Check for the Salt entitlement
     Given I am on the Systems overview page of this client
     Then I should see a "[Salt]" text
@@ -20,7 +17,8 @@ Feature: Verify the minion registration
     And I should see a "aaa_base-extras" text
 
   Scenario: Accepted minion has a base channel
-    Given that this minion is registered in Spacewalk
+    Given I am authorized as "testing" with password "testing"
+    And that this minion is registered in Spacewalk
     And I follow this client link
     And I follow "Software"
     And I follow "Software Channels"


### PR DESCRIPTION
This PR fixes:
- Scenario: Check for the Salt entitlement
- Scenario: Check installed packages are visible

We don't want to do a common login in "Background" for all scenarios because step `I am on the Systems overview page of this client` also handle the login for those tests. If multiple logins are done then tests will fail.

/cc @hustodemon @mseidl 