### PR TITLE
Check if package list is refreshed for the accepted minion

### DIFF
--- a/features/salt_minion_details.feature
+++ b/features/salt_minion_details.feature
@@ -11,8 +11,8 @@ Feature: Verify the minion registration
 
   Scenario: Check if package list has been refreshed
     Given I am on the Systems overview page of this client
-    And I wait for "10" seconds
-    When I follow "Events"
+    When I wait until packages list state is completed on the minion
+    And I follow "Events"
     And I follow "History"
     Then I should see a "Package List Refresh scheduled by (none)" text
 

--- a/features/salt_minion_details.feature
+++ b/features/salt_minion_details.feature
@@ -9,6 +9,13 @@ Feature: Verify the minion registration
     Given I am on the Systems overview page of this client
     Then I should see a "[Salt]" text
 
+  Scenario: Check if package list has been refreshed
+    Given I am on the Systems overview page of this client
+    And I wait for "10" seconds
+    When I follow "Events"
+    And I follow "History"
+    Then I should see a "Package List Refresh scheduled by (none)" text
+
   Scenario: Check installed packages are visible
     Given I am on the Systems overview page of this client
     When I follow "Software"

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -114,6 +114,25 @@ Then(/^the list of the keys should contain this client's hostname$/) do
   puts "Total time waited: #{time_waited}"
 end
 
+Then(/^I wait until packages list state is completed on the minion$/) do
+  completed = false
+  output = ""
+  begin
+    Timeout.timeout(30) do
+      loop do
+        output = `cat /var/log/salt/minion | egrep "Completed.*pkg.info_installed" 2>&1`
+        if output != ""
+          completed = true
+          break
+        end
+        sleep 1
+      end
+    end
+  rescue Timeout::Error
+    raise "package list state has not been completed"
+  end
+end
+
 Given(/^this minion key is unaccepted$/) do
   step "I list unaccepted keys at Salt Master"
   @output = @action.call


### PR DESCRIPTION
This PR adds a new scenario to the `Verify minion registration` feature:

1. Scenario: Check if package list has been refreshed

This should also fix a timing issue refreshing the package list that produces test failures in the next scenario if the refreshing has not been completed.

Changes are for `master` and `manager30` branches.

/cc @mseidl @hustodemon 