### PR TITLE
Fix: waiting and refreshing page until pending minion appears

### DIFF
--- a/features/salt_minions_page.feature
+++ b/features/salt_minions_page.feature
@@ -19,7 +19,7 @@ Feature: Explore the Minions page
     And I go to the minion onboarding page
     Then I should see this hostname as text
     And I see my fingerprint
-    Then I should see a "pending" text
+    Then I try to reload page until contains "pending" text
 
   Scenario: Reject and delete the pending minion key
     Given this minion key is unaccepted


### PR DESCRIPTION
This PR modifies the steps of:

1. Scenario: Minion is visible in the Pending section

Sometimes fingerprint hasn't appeared yet when test is loaded. Now, test is waiting and refreshing the page until it contains `pending` text.

This changes should be also merged in `master` branch.

/cc @mseidl 