### PR TITLE
Added 'pkgset' beacon tests for SLES and RHEL minions (slenkins branch)

### DIFF
--- a/features/salt_pkgset_beacon.feature
+++ b/features/salt_pkgset_beacon.feature
@@ -1,0 +1,24 @@
+# Copyright (c) 2016 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: System package list in the UI is updated if packages are manually installed/removed using zypper or yum
+
+  Scenario: Manually removing a package in a minion
+    Given this minion key is accepted
+    And I am on the Systems overview page of this minion
+    When I follow "Software"
+    And I follow "List / Remove"
+    And I follow "M"
+    And I should see a "milkyway-dummy" text
+    Then I manually remove the "milkyway-dummy" package in the minion
+    And I try to reload page until does not contain "milkyway-dummy" text
+
+  Scenario: Manually installing a package in a minion
+    Given this minion key is accepted
+    And I am on the Systems overview page of this minion
+    When I follow "Software"
+    And I follow "List / Remove"
+    And I follow "M"
+    And I should not see a "milkyway-dummy" text
+    Then I manually install the "milkyway-dummy" package in the minion
+    And I try to reload page until contains "milkyway-dummy" text

--- a/features/step_definitions/salt_pkgset_beacon_steps.rb
+++ b/features/step_definitions/salt_pkgset_beacon_steps.rb
@@ -1,0 +1,24 @@
+# Copyright (c) 2016 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Then(/^I manually install the "([^"]*)" package in the minion$/) do |package|
+  if file_exist($minion, "/usr/bin/zypper").zero?
+    cmd = "zypper --non-interactive install -y #{package}"
+  elsif file_exist($minion, "/usr/bin/yum").zero?
+    cmd = "yum -y install #{package}"
+  else
+    fail "not found: zypper or yum"
+  end
+  $minion.run(cmd, false)
+end
+
+Then(/^I manually remove the "([^"]*)" package in the minion$/) do |package|
+  if file_exist($minion, "/usr/bin/zypper").zero?
+    cmd = "zypper --non-interactive remove -y #{package}"
+  elsif file_exist($minion, "/usr/bin/yum").zero?
+    cmd = "yum -y remove #{package}"
+  else
+    fail "not found: zypper or yum"
+  end
+  $minion.run(cmd, false)
+end

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -41,6 +41,18 @@ Given(/^that the master can reach this client$/) do
   end
 end
 
+Given(/^I am on the Systems overview page of this minion$/) do
+  steps %(
+    Given I am on the Systems page
+    And I follow "Systems" in the left menu
+    And I follow this minion link
+    )
+end
+
+When(/^I follow this minion link$/) do
+  step %(I follow "#{$minion_hostname}")
+end
+
 When(/^I get the contents of the remote file "(.*?)"$/) do |filename|
   @output = sshcmd("cat #{filename}")
 end
@@ -252,4 +264,22 @@ Then(/^I try to reload page until contains "([^"]*)" text$/) do |arg1|
     raise "'#{arg1}' cannot be found after wait and reload page"
   end
   fail unless found
+end
+
+Then(/^I try to reload page until does not contain "([^"]*)" text$/) do |arg1|
+  not_found = false
+  begin
+    Timeout.timeout(30) do
+      loop do
+        unless page.has_content?(debrand_string(arg1))
+          not_found = true
+          break
+        end
+        visit current_url
+      end
+    end
+  rescue Timeout::Error
+    raise "'#{arg1}' found after wait and reload page"
+  end
+  fail unless not_found
 end

--- a/run_sets/minion.yml
+++ b/run_sets/minion.yml
@@ -5,6 +5,7 @@
 - features/salt_minion_details.feature
 - features/salt_download_endpoint.feature
 - features/salt_software_states.feature
+- features/salt_pkgset_beacon.feature
 - features/salt_remote_cmds.feature
 - features/salt_install_package.feature
 - features/salt_states_catalog.feature


### PR DESCRIPTION
This PR adds tests for the `pkgset` beacon for SLES and RHEL minions using SLEnkins:

1. Scenario: Manually removing a package in a minion 
2. Scenario: Manually installing a package in a minion

When users manually perform package installation or removal directly in the minion (using `zypper` or `yum` commands) then the `pkgset` beacon is aware of these changes and does report them to the SUMA UI.

So package changes manually done by `zypper` or `yum` actions are shown in the UI.

/cc @MalloZup @mseidl 
