### PR TITLE
Test: Salt-SSH bootstrapping

### DIFF
--- a/features/salt_ssh.feature
+++ b/features/salt_ssh.feature
@@ -13,14 +13,17 @@ Feature: Bootstrap a new salt host via salt-ssh
 
     Given I am authorized
        When I follow "Salt"
-       Then I should see a "Bootstrapping" text
+    Then I should see a "Bootstrapping" text
        And I follow "Bootstrapping"
-       Then I should see a "Bootstrap Minions" text
-       And I enter remote minion hostname as "hostname"
-       And I enter "22" as "port"
-       And I enter "root" as "user"
-       And I enter "linux" as "password"
+    Then I should see a "Bootstrap Minions" text
        And I check "manageWithSSH"
+       And I enter remote minion hostname as "hostname"
+       And I enter "linux" as "password"
        And I click on "Bootstrap it"
-       And I wait for "200" seconds
+       And I wait for "5" seconds
     Then I should see a "Successfully bootstrapped host! Your system should appear in System Overview shortly." text
+       And I wait for "10" seconds
+       And I follow "System Overview"
+    Then I should see remote minion hostname as link
+       And I follow remote minion hostname
+    Then I should see a "Push via SSH" text

--- a/features/salt_ssh.feature
+++ b/features/salt_ssh.feature
@@ -1,0 +1,26 @@
+# Copyright (c) 2016 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Bootstrap a new salt host via salt-ssh
+  In order to operate SUSE Manager based on salt-ssh
+  I want to verify general salt functionality and system registration
+
+  Background:
+    Given no Salt packages are installed on remote minion host
+    And remote minion host is not registered in Spacewalk
+
+  Scenario: Bootstrap a system via salt-ssh
+
+    Given I am authorized
+       When I follow "Salt"
+       Then I should see a "Bootstrapping" text
+       And I follow "Bootstrapping"
+       Then I should see a "Bootstrap Minions" text
+       And I enter remote minion hostname as "hostname"
+       And I enter "22" as "port"
+       And I enter "root" as "user"
+       And I enter "linux" as "password"
+       And I check "manageWithSSH"
+       And I click on "Bootstrap it"
+       And I wait for "200" seconds
+    Then I should see a "Successfully bootstrapped host! Your system should appear in System Overview shortly." text

--- a/features/step_definitions/salt_ssh_steps.rb
+++ b/features/step_definitions/salt_ssh_steps.rb
@@ -4,8 +4,8 @@
 SALT_PACKAGES="salt salt-minion"
 
 Given(/^no Salt packages are installed on remote minion host$/) do
-  output = sshcmd("test -e /usr/bin/zypper && zypper --non-interactive remove -y #{SALT_PACKAGES}", host: "#{ENV['MINION']}", user: "root", ignore_err: true)
-  output = sshcmd("test -e /usr/bin/yum && yum -y remove #{SALT_PACKAGES}", host: "#{ENV['MINION']}", user: "root", ignore_err: true)
+  sshcmd("test -e /usr/bin/zypper && zypper --non-interactive remove -y #{SALT_PACKAGES}", host: "#{ENV['MINION']}", user: "root", ignore_err: true)
+  sshcmd("test -e /usr/bin/yum && yum -y remove #{SALT_PACKAGES}", host: "#{ENV['MINION']}", user: "root", ignore_err: true)
 end
 
 Given(/^remote minion host is not registered in Spacewalk$/) do

--- a/features/step_definitions/salt_ssh_steps.rb
+++ b/features/step_definitions/salt_ssh_steps.rb
@@ -1,0 +1,21 @@
+# Copyright (c) 2016 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+SALT_PACKAGES="salt salt-minion"
+
+Given(/^no Salt packages are installed on remote minion host$/) do
+  output = sshcmd("test -e /usr/bin/zypper && zypper --non-interactive remove -y #{SALT_PACKAGES}", host: "#{ENV['MINION']}", user: "root", ignore_err: true)
+  output = sshcmd("test -e /usr/bin/yum && yum -y remove #{SALT_PACKAGES}", host: "#{ENV['MINION']}", user: "root", ignore_err: true)
+end
+
+Given(/^remote minion host is not registered in Spacewalk$/) do
+  @rpc = XMLRPCSystemTest.new(ENV['TESTHOST'])
+  @rpc.login('admin', 'admin')
+  sid = @rpc.listSystems.select { |s| s['name'] == ENV['MINION'] }.map { |s| s['id'] }.first
+  @rpc.deleteSystem(sid) if sid
+  refute_includes(@rpc.listSystems.map { |s| s['id'] }, ENV['MINION'])
+end
+
+Then(/^I enter remote minion hostname as "(.*?)"$/) do |arg1|
+  step %(I enter "#{ENV['MINION']}" as "hostname")
+end

--- a/features/step_definitions/salt_ssh_steps.rb
+++ b/features/step_definitions/salt_ssh_steps.rb
@@ -19,3 +19,11 @@ end
 Then(/^I enter remote minion hostname as "(.*?)"$/) do |arg1|
   step %(I enter "#{ENV['MINION']}" as "hostname")
 end
+
+Then(/^I should see remote minion hostname as link$/) do
+  step %(I should see a "#{ENV['MINION']}" link)
+end
+
+Then(/^I follow remote minion hostname$/) do
+  step %(I follow "#{ENV['MINION']}")
+end

--- a/features/step_definitions/salt_ssh_steps.rb
+++ b/features/step_definitions/salt_ssh_steps.rb
@@ -1,11 +1,11 @@
 # Copyright (c) 2016 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-SALT_PACKAGES="salt salt-minion"
+SALT_PACKAGES = "salt salt-minion".freeze
 
 Given(/^no Salt packages are installed on remote minion host$/) do
-  sshcmd("test -e /usr/bin/zypper && zypper --non-interactive remove -y #{SALT_PACKAGES}", host: "#{ENV['MINION']}", user: "root", ignore_err: true)
-  sshcmd("test -e /usr/bin/yum && yum -y remove #{SALT_PACKAGES}", host: "#{ENV['MINION']}", user: "root", ignore_err: true)
+  sshcmd("test -e /usr/bin/zypper && zypper --non-interactive remove -y #{SALT_PACKAGES}", host: ENV['MINION'].to_s, user: "root", ignore_err: true)
+  sshcmd("test -e /usr/bin/yum && yum -y remove #{SALT_PACKAGES}", host: ENV['MINION'].to_s, user: "root", ignore_err: true)
 end
 
 Given(/^remote minion host is not registered in Spacewalk$/) do
@@ -16,8 +16,8 @@ Given(/^remote minion host is not registered in Spacewalk$/) do
   refute_includes(@rpc.listSystems.map { |s| s['id'] }, ENV['MINION'])
 end
 
-Then(/^I enter remote minion hostname as "(.*?)"$/) do |arg1|
-  step %(I enter "#{ENV['MINION']}" as "hostname")
+Then(/^I enter remote minion hostname as "(.*?)"$/) do |hostname|
+  step %(I enter "#{ENV['MINION']}" as "#{hostname}")
 end
 
 Then(/^I should see remote minion hostname as link$/) do

--- a/run_sets/minion.yml
+++ b/run_sets/minion.yml
@@ -9,4 +9,5 @@
 - features/salt_action_pickedup.feature
 - features/salt_install_package.feature
 - features/salt_states_catalog.feature
+- features/salt_ssh.feature
 - features/spacewalk-debug.feature


### PR DESCRIPTION
NOTE: before merging, a66a332f8306764fce2b27cd3d5b06d6e191448a should
be `revert`-ed in Manager-3.0

Add Cucumber tests for salt-ssh bootstrapping. Only bootstrap is tested
at the moment (other features are not implemented yet).

Tested with sumaform with main.tf.libvirt-testsuite plain configuration.