### PR TITLE
Total of available public api calls set to '675'

### DIFF
--- a/features/xmlrpc_api.feature
+++ b/features/xmlrpc_api.feature
@@ -8,5 +8,5 @@ Feature: Test XML-RPC "api" namespace.
     When I call getVersion, I should get "17" as result
     And I call systemVersion, I should get "3.0" as result
     And I call getApiNamespaces, I should get 48 namespaces
-    And I call getApiNamespaceCallList, I should get 674 available api calls
+    And I call getApiNamespaceCallList, I should get 675 available api calls
     And I call getApiCallList, I should get 48 available groups


### PR DESCRIPTION
This PR set the total available public API calls to `675`.

We introduced a new method 'getInstalledProducts' (https://github.com/SUSE/spacewalk/pull/809) which is now returned by the `getApiNamespaceCallList` call. We need to increase the expected number of methods returned by this call to fix a failing test in our testsuite.

@cbbayburt - Are you agreed with this changes?