### PR TITLE
BUGFIX: put changepwd feature at the end.

### DIFF
--- a/run_sets/testsuite.yml
+++ b/run_sets/testsuite.yml
@@ -66,7 +66,6 @@
 - features/xmlrpc_VHM.feature
 - features/check_VHM.feature
 - features/setup_wizard.feature
-- features/change_password.feature
 ###- features/mgr_create_bootstrap_repo.feature
 - features/security.feature
 
@@ -83,4 +82,8 @@
 - features/salt_states_catalog.feature
 - features/spacewalk-errors.feature
 - features/spacewalk-debug.feature
+
+## smdba and change password feature always put them at the end of the testsuite.
+## if they fails, they break the whole testsuite.
 - features/smdba.feature
+- features/change_password.feature


### PR DESCRIPTION
This feature, if fail(sometimes does)
can break whole suite, so always put it at the end