### PR TITLE
New feature: migrate a traditional client into a salt minion

### DIFF
--- a/features/migrate_client_to_minion.feature
+++ b/features/migrate_client_to_minion.feature
@@ -1,0 +1,30 @@
+# Copyright (c) 2017 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Migrate a traditional client into a salt minion
+
+  Scenario: Migrate a sles client into a salt minion
+     Given I am authorized
+     When I follow "Salt"
+     Then I should see a "Bootstrapping" text
+     And I follow "Bootstrapping"
+     Then I should see a "Bootstrap Minions" text
+     # sle-client = traditional sles client
+     And I enter the hostname of "sle-client" as hostname
+     And I enter "22" as "port"
+     And I enter "root" as "user"
+     And I enter "linux" as "password"
+     And I select "1-SUSE-PKG-x86_64" from "activationKeys"
+     And I click on "Bootstrap"
+     And I wait for "100" seconds
+     Then I should see a "Successfully bootstrapped host! Your system should appear in System Overview shortly." text
+
+  Scenario: Verify the minion was bootstrapped with activation key
+     Given I am on the Systems overview page of this "sle-client"
+     Then I should see a "Activation Key: 	1-SUSE-PKG" text
+
+  Scenario: Check that service nhsd has been stopped
+     # bsc#1020902 - moving from traditional to salt with bootstrap is not disabling rhnsd
+     When I run "systemctl status nhsd | grep Active" on "sle-client"
+     Then the command should fail
+

--- a/features/step_definitions/minion_bootstrap_steps.rb
+++ b/features/step_definitions/minion_bootstrap_steps.rb
@@ -2,13 +2,15 @@
 # Licensed under the terms of the MIT license.
 
 And(/^I enter the hostname of "([^"]*)" as hostname$/) do |minion|
-  if minion == "sle-minion"
+  case minion
+  when "sle-minion"
     step %(I enter "#{$minion_fullhostname}" as "hostname")
-
-  elsif minion == "ceos-minion"
+  when "ceos-minion"
     step %(I enter "#{$ceos_minion_fullhostname}" as "hostname")
+  when "sle-client"
+    step %(I enter "#{$client_fullhostname}" as "hostname")
   else
-    raise "no valid name of minion given! "
+    raise "No valid target."
   end
 end
 


### PR DESCRIPTION
Kind of minimalistic for the time being. Tests for bsc#1020902, but should also test many other aspects of the minion are like before the migration.

Ideally, we would also migrate a traditional Centos client, especially for bsc#1012956. But that would mean one more VM for one test only... :-(