### PR TITLE
Test scenarios for migration from classical client to Salt minion

### DIFF
--- a/features/action_chain.feature
+++ b/features/action_chain.feature
@@ -127,4 +127,4 @@ Feature: Test action chaining
     Then I click on "Save and Schedule"
     And I should see a "Action Chain new action chain has been scheduled for execution." text
     When I run rhn_check on this client
-    Then "/root/webui-actionchain-test" exists on the filesystem
+    Then "/root/webui-actionchain-test" exists on the filesystem of "sle-client"

--- a/features/migrate_client_to_minion.feature
+++ b/features/migrate_client_to_minion.feature
@@ -70,8 +70,9 @@ Feature: Migrate a traditional client into a salt minion
      And I enter as remote command this script in
       """
       #!/bin/bash
-      touch /tmp/tastes-better-with-salt
+      touch /tmp/remote-command-on-migrated-text
       """
      And I click on "Schedule"
      Then I should see a "Remote Command has been scheduled successfully" text
-     And "/tmp/tastes-better-with-salt" exists on the filesystem
+     And "/tmp/remote-command-on-migrated-test" exists on the filesystem of "sle-migrated-minion"
+     And I remove "/tmp/remote-command-on-migrated-test" from "sle-migrated-minion"

--- a/features/salt_remote_cmds.feature
+++ b/features/salt_remote_cmds.feature
@@ -40,7 +40,7 @@ Feature: Test the remote commands via salt
       """
     And I click on "Schedule"
     Then I should see a "Remote Command has been scheduled successfully" text
-    And "/root/12345" exists on the filesystem
+    And "/root/12345" exists on the filesystem of "sle-minion"
     And I follow "Events" in the content area
     And I follow "History" in the content area
     Then I follow "Run an arbitrary script scheduled by testing" in the content area

--- a/features/salt_states_catalog.feature
+++ b/features/salt_states_catalog.feature
@@ -42,4 +42,4 @@ Feature: Check the Salt package state UI
     Then I should see a "1 Changes" text
     And I click on the css "button#save-btn"
     And I click on the css "button#apply-btn"
-    Then I wait for the file "/root/foobar"
+    Then "/root/foobar" exists on the filesystem of "sle-minion"

--- a/features/step_definitions/lock_packages_on_client.rb
+++ b/features/step_definitions/lock_packages_on_client.rb
@@ -3,7 +3,7 @@
 
 Then(/^"(.*?)" is locked on this client$/) do |pkg|
   zypp_lock_file = "/etc/zypp/locks"
-  fail unless file_exist($client, zypp_lock_file)
+  fail unless file_exists?($client, zypp_lock_file)
   command = "zypper locks  --solvables | grep #{pkg}"
   $client.run(command, true, 600, 'root')
 end
@@ -17,7 +17,7 @@ end
 
 Then(/^"(.*?)" is unlocked on this client$/) do |pkg|
   zypp_lock_file = "/etc/zypp/locks"
-  fail unless file_exist($client, zypp_lock_file)
+  fail unless file_exists?($client, zypp_lock_file)
   command = "zypper locks  --solvables | grep #{pkg}"
   $client.run(command, false, 600, 'root')
 end

--- a/features/step_definitions/register_client_steps.rb
+++ b/features/step_definitions/register_client_steps.rb
@@ -61,13 +61,13 @@ When(/^I follow this client link$/) do
 end
 
 Then(/^config-actions are enabled$/) do
-  unless  file_exist($client, '/etc/sysconfig/rhn/allowed-actions/configfiles/all')
+  unless file_exists?($client, '/etc/sysconfig/rhn/allowed-actions/configfiles/all')
     raise "config actions are disabled: /etc/sysconfig/rhn/allowed-actions/configfiles/all does not exist on client"
   end
 end
 
 Then(/^remote-commands are enabled$/) do
-  unless file_exist($client, '/etc/sysconfig/rhn/allowed-actions/script/run')
+  unless file_exists?($client, '/etc/sysconfig/rhn/allowed-actions/script/run')
     raise "remote-commands are disabled: /etc/sysconfig/rhn/allowed-actions/script/run does not exist"
   end
 end

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -8,7 +8,7 @@ Given(/^the Salt Minion is configured$/) do
   step %(I stop salt-minion)
   step %(I stop salt-master)
   key = '/etc/salt/pki/minion/minion_master.pub'
-  if file_exist($minion, key)
+  if file_exists?($minion, key)
     file_delete($minion, key)
     puts "Key #{key} has been removed on minion"
   end
@@ -317,25 +317,11 @@ Then(/^I should see "([^"]*)" in the command output$/) do |text|
   end
 end
 
-When(/^"(.*)" exists on the filesystem$/) do |file|
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break if file_exist($minion, file)
-        sleep(1)
-      end
-    end
-  rescue Timeout::Error
-    puts "timeout waiting for the file to appear"
-  end
-  fail unless file_exist($minion, file)
-end
-
 # salt_pkgset_beacon_steps.rb
 Then(/^I manually install the "([^"]*)" package in the minion$/) do |package|
-  if file_exist($minion, "/usr/bin/zypper").zero?
+  if file_exists?($minion, "/usr/bin/zypper")
     cmd = "zypper --non-interactive install -y #{package}"
-  elsif file_exist($minion, "/usr/bin/yum").zero?
+  elsif file_exists?($minion, "/usr/bin/yum")
     cmd = "yum -y install #{package}"
   else
     fail "not found: zypper or yum"
@@ -344,9 +330,9 @@ Then(/^I manually install the "([^"]*)" package in the minion$/) do |package|
 end
 
 Then(/^I manually remove the "([^"]*)" package in the minion$/) do |package|
-  if file_exist($minion, "/usr/bin/zypper").zero?
+  if file_exists?($minion, "/usr/bin/zypper")
     cmd = "zypper --non-interactive remove -y #{package}"
-  elsif file_exist($minion, "/usr/bin/yum").zero?
+  elsif file_exists?($minion, "/usr/bin/yum")
     cmd = "yum -y remove #{package}"
   else
     fail "not found: zypper or yum"
@@ -389,13 +375,4 @@ end
 
 When(/^I select the state "(.*)"$/) do |state|
   find("input##{state}-cbox").click
-end
-
-When(/^I wait for the file "(.*)"$/) do |file|
-  # Wait 60 seconds for file to appear
-  60.times do
-    break if file_exist($minion, file)
-    sleep 1
-  end
-  fail unless file_exist($minion, file)
 end

--- a/features/step_definitions/weak_deps_steps.rb
+++ b/features/step_definitions/weak_deps_steps.rb
@@ -23,7 +23,7 @@ end
 Then(/^"([^"]*)" should exists in the metadata$/) do |file|
   arch, _code = $client.run("uname -m")
   arch.chomp!
-  fail unless file_exist($client, "#{client_raw_repodata_dir("sles11-sp3-updates-#{arch}-channel")}/#{file}")
+  fail unless file_exists?($client, "#{client_raw_repodata_dir("sles11-sp3-updates-#{arch}-channel")}/#{file}")
 end
 
 Then(/^I should have '([^']*)' in the patch metadata$/) do |text|

--- a/features/support/twopence_init.rb
+++ b/features/support/twopence_init.rb
@@ -58,9 +58,29 @@ $ssh_minion_hostname = node_hostnames[4]
 $ssh_minion_fullhostname = node_fqn[4]
 
 # helper functions for moment this are used in salt.steps but maybe move this to lavanda.rb
-def file_exist(node, file)
+def get_target(host)
+  case host
+  when "server"
+    node = $server
+  when "ceos-minion"
+    node = $ceos_minion
+  when "ssh-minion"
+    node = $ssh_minion
+  when "sle-minion"
+    node = $minion
+  when "sle-client"
+    node = $client
+  when "sle-migrated-minion"
+    node = $client
+  else
+    raise "Invalid target."
+  end
+  node
+end
+
+def file_exists?(node, file)
   _out, _local, _remote, code = node.test_and_store_results_together("test -f #{file}", "root", 500)
-  code
+  code.zero?
 end
 
 def file_delete(node, file)


### PR DESCRIPTION
These tests test migration from traditional client to Salt minion.

They have been tried in isolation and do work in such conditions.

They DO FAIL when run inside of the whole test suite because of product bug bsc#1023399 - "Migrate a traditional client in SSH push mode into a salt minion doesn't work", but that is expected.
