### PR TITLE
[WIP:]Backport from 3.1: migration tests, fixes

### DIFF
--- a/features/action_chain.feature
+++ b/features/action_chain.feature
@@ -126,4 +126,4 @@ Feature: Test action chaining
     Then I click on "Save and Schedule"
     And I should see a "Action Chain new action chain has been scheduled for execution." text
     When I run rhn_check on this client
-    Then "/root/webui-actionchain-test" exists on the filesystem
+    Then "/root/webui-actionchain-test" exists on the filesystem of "sle-client"

--- a/features/migrate_client_to_minion.feature
+++ b/features/migrate_client_to_minion.feature
@@ -1,0 +1,78 @@
+# Copyright (c) 2017 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Migrate a traditional client into a salt minion
+  In order to move away from traditional clients
+  As an authorized user
+  I want to migrate these clients to salt minions and have everything as before
+
+  Scenario: Migrate a sles client into a salt minion
+     Given I am authorized
+     When I follow "Salt"
+     And I follow "Bootstrapping"
+     # sle-migrated-minion = traditional sles client
+     And I enter the hostname of "sle-migrated-minion" as hostname
+     And I enter "22" as "port"
+     And I enter "root" as "user"
+     And I enter "linux" as "password"
+     And I select "1-SUSE-PKG-x86_64" from "activationKeys"
+     And I click on "Bootstrap"
+     And I wait for "100" seconds
+     Then I should see a "Successfully bootstrapped host! Your system should appear in System Overview shortly." text
+
+  Scenario: Verify the minion was bootstrapped with activation key
+     Given I am on the Systems overview page of this client
+     Then I should see a "Activation Key: 	1-SUSE-PKG" text
+
+  Scenario: Check that service nhsd has been stopped
+     # bsc#1020902 - moving from traditional to salt with bootstrap is not disabling rhnsd
+     When I run "systemctl status nhsd" on "sle-migrated-minion"
+     Then the command should fail
+
+  Scenario: Check that the migrated system is now a minion
+     # bsc1023399 - Migrate a traditional client in SSH push mode into a salt minion doesn't work
+     Given I am on the Systems overview page of this client
+     When I follow "Properties" in the content area
+     Then I should see a "Base System Type:     Salt" text
+
+  Scenario: Check that channels are still the same after migration
+     Given I am on the Systems overview page of this client
+     When I follow "Software" in the content area
+     And I follow "Software Channels" in the content area
+     Then I should see a "SLES11-SP3-Updates x86_64 Channel" text
+     And I should see a "Test Base Channel" text
+
+  Scenario: Check that groups are still the same after migration
+     Given I am on the Systems overview page of this client
+     When I follow "Groups" in the content area
+     Then I should see a "newgroup" text
+
+  Scenario: Check that events history is still the same after migration
+     Given I am on the Systems overview page of this client
+     When I follow "Events" in the content area
+     And I follow "History" in the content area
+     Then I should see a "Subscription via Token" text
+
+  Scenario: Install a package onto the migrated minion
+     Given I am on the Systems overview page of this client
+     When I follow "Software" in the content area
+     And I follow "Install"
+     And I check "perseus-dummy-1.1-1.1" in the list
+     And I click on "Install Selected Packages"
+     And I click on "Confirm"
+     And I wait for "5" seconds
+     Then I should see a "1 package install has been scheduled for" text
+     And I wait for "perseus-dummy-1.1-1.1" to be installed
+
+  Scenario: Run a remote command on the migrated minion
+     Given I am on the Systems overview page of this client
+     When I follow "Remote Command" in the content area
+     And I enter as remote command this script in
+      """
+      #!/bin/bash
+      touch /tmp/remote-command-on-migrated-text
+      """
+     And I click on "Schedule"
+     Then I should see a "Remote Command has been scheduled successfully" text
+     And "/tmp/remote-command-on-migrated-test" exists on the filesystem of "sle-migrated-minion"
+     And I remove "/tmp/remote-command-on-migrated-test" from "sle-migrated-minion"

--- a/features/salt_remote_cmds.feature
+++ b/features/salt_remote_cmds.feature
@@ -40,7 +40,7 @@ Feature: Test the remote commands via salt
       """
     And I click on "Schedule"
     Then I should see a "Remote Command has been scheduled successfully" text
-    And "/root/12345" exists on the filesystem
+    And "/root/12345" exists on the filesystem of "salt-minion"
     And I follow "Events" in the content area
     And I follow "History" in the content area
     Then I follow "Run an arbitrary script scheduled by testing" in the content area

--- a/features/salt_states_catalog.feature
+++ b/features/salt_states_catalog.feature
@@ -42,4 +42,4 @@ Feature: Check the Salt package state UI
     Then I should see a "1 Changes" text
     And I click on the css "button#save-btn"
     And I click on the css "button#apply-btn"
-    Then I wait for the file "/root/foobar"
+    Then "/root/foobar" exists on the filesystem of "sle-minion"

--- a/features/step_definitions/command_steps.rb
+++ b/features/step_definitions/command_steps.rb
@@ -229,18 +229,30 @@ Then(/^Service "([^"]*)" is running on the Server$/) do |service|
     fail if output != "active"
 end
 
-When(/^I run "([^"]*)" on "([^"]*)"$/) do |cmd, target|
-  case target
-  when "server"
-    _out, $fail_code = $server.run(cmd, false)
-  when "ceos-minion"
-    _out, $fail_code = $ceos_minion.run(cmd, false)
-  when "ssh-minion"
-    _out, $fail_code = $ssh_minion.run(cmd, false)
-  else
-    raise "Invalid target."
-  end
+When(/^I run "([^"]*)" on "([^"]*)"$/) do |cmd, host|
+  node = get_target(host)
+  _out, $fail_code = node.run(cmd, false)
 end
 Then(/^the command should fail$/) do
    raise "Previous command must fail, but has NOT failed!" if $fail_code.zero?
+end
+
+When(/^"(.*)" exists on the filesystem of "(.*)"$/) do |file, host|
+  node = get_target(host)
+  begin
+    Timeout.timeout(DEFAULT_TIMEOUT) do
+      loop do
+        break if file_exists?(node, file)
+        sleep(1)
+      end
+    end
+  rescue Timeout::Error
+    puts "timeout waiting for the file to appear"
+  end
+  fail unless file_exists?(node, file)
+end
+
+Then(/^I remove "(.*)" from "(.*)"$/) do |file, host|
+  node = get_target(host)
+  file_delete(node, file)
 end

--- a/features/step_definitions/lock_packages_on_client.rb
+++ b/features/step_definitions/lock_packages_on_client.rb
@@ -3,7 +3,7 @@
 
 Then(/^"(.*?)" is locked on this client$/) do |pkg|
   zypp_lock_file = "/etc/zypp/locks"
-  fail unless file_exist($client, zypp_lock_file)
+  fail unless file_exists?($client, zypp_lock_file)
   command = "zypper locks  --solvables | grep #{pkg}"
   $client.run(command, true, 600, 'root')
 end
@@ -17,7 +17,7 @@ end
 
 Then(/^"(.*?)" is unlocked on this client$/) do |pkg|
   zypp_lock_file = "/etc/zypp/locks"
-  fail unless file_exist($client, zypp_lock_file)
+  fail unless file_exists?($client, zypp_lock_file)
   command = "zypper locks  --solvables | grep #{pkg}"
   $client.run(command, false, 600, 'root')
 end

--- a/features/step_definitions/minion_bootstrap_steps.rb
+++ b/features/step_definitions/minion_bootstrap_steps.rb
@@ -2,13 +2,15 @@
 # Licensed under the terms of the MIT license.
 
 And(/^I enter the hostname of "([^"]*)" as hostname$/) do |minion|
-  if minion == "sle-minion"
+  case minion
+  when "sle-minion"
     step %(I enter "#{$minion_fullhostname}" as "hostname")
-
-  elsif minion == "ceos-minion"
+  when "ceos-minion"
     step %(I enter "#{$ceos_minion_fullhostname}" as "hostname")
+  when "sle-migrated-minion"
+    step %(I enter "#{$client_fullhostname}" as "hostname")
   else
-    raise "no valid name of minion given! "
+    raise "No valid target."
   end
 end
 

--- a/features/step_definitions/register_client_steps.rb
+++ b/features/step_definitions/register_client_steps.rb
@@ -68,13 +68,13 @@ When(/^I follow this client link$/) do
 end
 
 Then(/^config-actions are enabled$/) do
-  unless  file_exist($client, '/etc/sysconfig/rhn/allowed-actions/configfiles/all')
+  unless file_exists?($client, '/etc/sysconfig/rhn/allowed-actions/configfiles/all')
     raise "config actions are disabled: /etc/sysconfig/rhn/allowed-actions/configfiles/all does not exist on client"
   end
 end
 
 Then(/^remote-commands are enabled$/) do
-  unless file_exist($client, '/etc/sysconfig/rhn/allowed-actions/script/run')
+  unless file_exists?($client, '/etc/sysconfig/rhn/allowed-actions/script/run')
     raise "remote-commands are disabled: /etc/sysconfig/rhn/allowed-actions/script/run does not exist"
   end
 end

--- a/features/step_definitions/salt_pkgset_beacon_steps.rb
+++ b/features/step_definitions/salt_pkgset_beacon_steps.rb
@@ -2,9 +2,9 @@
 # Licensed under the terms of the MIT license.
 
 Then(/^I manually install the "([^"]*)" package in the minion$/) do |package|
-  if file_exist($minion, "/usr/bin/zypper").zero?
+  if file_exists?($minion, "/usr/bin/zypper")
     cmd = "zypper --non-interactive install -y #{package}"
-  elsif file_exist($minion, "/usr/bin/yum").zero?
+  elsif file_exists?($minion, "/usr/bin/yum")
     cmd = "yum -y install #{package}"
   else
     fail "not found: zypper or yum"
@@ -13,9 +13,9 @@ Then(/^I manually install the "([^"]*)" package in the minion$/) do |package|
 end
 
 Then(/^I manually remove the "([^"]*)" package in the minion$/) do |package|
-  if file_exist($minion, "/usr/bin/zypper").zero?
+  if file_exists?($minion, "/usr/bin/zypper")
     cmd = "zypper --non-interactive remove -y #{package}"
-  elsif file_exist($minion, "/usr/bin/yum").zero?
+  elsif file_exists?($minion, "/usr/bin/yum")
     cmd = "yum -y remove #{package}"
   else
     fail "not found: zypper or yum"

--- a/features/step_definitions/salt_remote_cmds.rb
+++ b/features/step_definitions/salt_remote_cmds.rb
@@ -36,17 +36,3 @@ Then(/^I should see "([^"]*)" in the command output$/) do |arg1|
     fail unless page.has_content?('SuSE-release')
   end
 end
-
-When(/^"(.*)" exists on the filesystem$/) do |file|
-  begin
-    Timeout.timeout(DEFAULT_TIMEOUT) do
-      loop do
-        break if file_exist($minion, file)
-        sleep(1)
-      end
-    end
-  rescue Timeout::Error
-    puts "timeout waiting for the file to appear"
-  end
-  fail unless file_exist($minion, file)
-end

--- a/features/step_definitions/salt_states_catalog_steps.rb
+++ b/features/step_definitions/salt_states_catalog_steps.rb
@@ -18,12 +18,3 @@ end
 When(/^I select the state "(.*)"$/) do |state|
   find("input##{state}-cbox").click
 end
-
-When(/^I wait for the file "(.*)"$/) do |file|
-  # Wait 60 seconds for file to appear
-  60.times do
-    break if file_exist($minion, file)
-    sleep 1
-  end
-  fail unless file_exist($minion, file)
-end

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -8,7 +8,7 @@ Given(/^the Salt Minion is configured$/) do
   step %(I stop salt-minion)
   step %(I stop salt-master)
   key = '/etc/salt/pki/minion/minion_master.pub'
-  if file_exist($minion, key)
+  if file_exists?($minion, key)
     file_delete($minion, key)
     puts "Key #{key} has been removed on minion"
   end

--- a/features/step_definitions/weak_deps_steps.rb
+++ b/features/step_definitions/weak_deps_steps.rb
@@ -23,7 +23,7 @@ end
 Then(/^"([^"]*)" should exists in the metadata$/) do |file|
   arch, _code = $client.run("uname -m")
   arch.chomp!
-  fail unless file_exist($client, "#{client_raw_repodata_dir("sles11-sp3-updates-#{arch}-channel")}/#{file}")
+  fail unless file_exists?($client, "#{client_raw_repodata_dir("sles11-sp3-updates-#{arch}-channel")}/#{file}")
 end
 
 Then(/^I should have '([^']*)' in the patch metadata$/) do |text|

--- a/features/support/twopence_init.rb
+++ b/features/support/twopence_init.rb
@@ -57,9 +57,29 @@ $ssh_minion_hostname = node_hostnames[4]
 $ssh_minion_fullhostname = node_fqn[4]
 
 # helper functions for moment this are used in salt.steps but maybe move this to lavanda.rb
-def file_exist(node, file)
+def get_target(host)
+  case host
+  when "server"
+    node = $server
+  when "ceos-minion"
+    node = $ceos_minion
+  when "ssh-minion"
+    node = $ssh_minion
+  when "sle-minion"
+    node = $minion
+  when "sle-client"
+    node = $client
+  when "sle-migrated-minion"
+    node = $client
+  else
+    raise "Invalid target."
+  end
+  node
+end
+
+def file_exists?(node, file)
   _out, _local, _remote, code = node.test_and_store_results_together("test -f #{file}", "root", 500)
-  code
+  code.zero?
 end
 
 def file_delete(node, file)

--- a/run_sets/testsuite.yml
+++ b/run_sets/testsuite.yml
@@ -84,6 +84,7 @@
 - features/minion_bootstrap.feature
 # Regression test
 - features/salt_regression_topsls.feature
+- features/migrate_client_to_minion.feature
 
 ### Salt-ssh managed feature ##
 - features/salt_ssh.feature


### PR DESCRIPTION
Tests backported from HEAD branch:
 * new migration tests
 * tell which system we check for a file
 * fixed bug of file_exist() that was always returning true