### PR TITLE
Fixed salt formulas testing

### DIFF
--- a/features/salt_formulas.feature
+++ b/features/salt_formulas.feature
@@ -40,9 +40,7 @@ Feature: Use salt formulas
      And I click on "Apply Highstate"
      Then I should see a "Applying the highstate has been scheduled." text
      And I wait for "40" seconds
-     ### following test always fails because of salt states left by sumaform
-     # And the timezone on "sle-minion" should be "+05"
-     ### disabling temporarily
+     And the timezone on "sle-minion" should be "+05"
      And the keymap on "sle-minion" should be "ca.map.gz"
      And the language on "sle-minion" should be "fr_FR.UTF-8"
 

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -429,8 +429,8 @@ Then(/^the language on "([^"]*)" should be "([^"]*)"$/) do |minion, language|
   else
     fail "Invalid target"
   end
-  output, _code = target.run("grep 'RC_LANG=' /etc/sysconfig/language")
-  fail unless output.strip == "RC_LANG=\"#{language}\""
+  output, _code = target.run("grep 'LANG=' /etc/locale.conf")
+  fail unless output.strip == "LANG=#{language}"
 end
 
 When(/^I refresh the pillar data$/) do
@@ -438,6 +438,6 @@ When(/^I refresh the pillar data$/) do
 end
 
 Then(/^the pillar data for "([^"]*)" should be "([^"]*)"$/) do |key, value|
-  output, _code = $server.run("salt '*' pillar.get '#{key}'")
+  output, _code = $server.run("salt '#{$minion_ip}' pillar.get '#{key}'")
   fail unless output.split("\n")[1].strip == value
 end


### PR DESCRIPTION
- update: now that the testsuite removes the states from sumaform,
  the test of timezone can be enabled again
- update: when applying locale.system state,
  salt 2016.11.3 changes /etc/locale.conf while
  salt 2015.8.12 used to change /etc/sysconfig/language
- optimization: instead of targetting '*' in the salt command,
  target the minion only