### PR TITLE
Testing salt formulas: backport to 3.0

### DIFF
--- a/features/init_user_create.feature
+++ b/features/init_user_create.feature
@@ -10,6 +10,7 @@ Feature: Create initial users
   @first
   Scenario: Create Admin users and first org
     Given I access the host the first time
+    And  I run "rm -Rf /srv/salt/*" on "server"
     When I go to the home page
     And I enter "SUSE Test" as "orgName"
     And I enter "admin" as "login"

--- a/features/salt_formulas.feature
+++ b/features/salt_formulas.feature
@@ -1,0 +1,51 @@
+# Copyright (c) 2017 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Use salt formulas
+  In order to use simple forms to apply changes to minions
+  As an authorized user
+  I want to be able to install and use salt formulas
+
+  Scenario: Install a formula package on the server
+     Given I am authorized
+     When I manually install the "locale" formula on the server
+     And I reload the page
+     And I follow "Salt"
+     And I follow "Formula Catalog"
+     Then I should see a "locale" text
+
+  Scenario: Enable the formula on the minion
+     Given I am on the Systems overview page of this minion
+     When I follow "Formulas" in the content area
+     Then I should see a "Choose formulas:" text
+     And I should see a "General System Configuration" text
+     And I should see a "Locale" text
+     When I check the "locale" formula
+     And I click on "Save"
+     Then the "locale" formula should be checked
+
+  Scenario: Parametrize the formula on the minion
+     Given I am on the Systems overview page of this minion
+     When I follow "Formulas" in the content area
+     And I follow "Locale" in the content area
+     And I select "Etc/GMT-5" in timezone name field
+     And I select "French" in language field
+     And I select "French (Canada)" in keyboard layout field
+     And I click on "Save Formula"
+     Then I should see a "Formula saved!" text
+
+  Scenario: Apply the formula via the highstate
+     Given I am on the Systems overview page of this minion
+     When I follow "Formulas" in the content area
+     And I click on "Apply Highstate"
+     Then I should see a "Applying the highstate has been scheduled." text
+     And I wait for "40" seconds
+     And the timezone on "sle-minion" should be "+05"
+     And the keymap on "sle-minion" should be "ca.map.gz"
+     And the language on "sle-minion" should be "fr_FR.UTF-8"
+
+  Scenario: Check the pillar data
+     When I refresh the pillar data
+     Then the pillar data for "timezone:name" should be "Etc/GMT-5"
+     And the pillar data for "keyboard_and_language:keyboard_layout" should be "French (Canada)"
+     And the pillar data for "keyboard_and_language:language" should be "French"

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -151,3 +151,25 @@ end
 When(/^I enter "(.*?)" in the editor$/) do |arg1|
   page.execute_script("ace.edit('contents-editor').setValue('#{arg1}')")
 end
+
+Then(/^I reload the page$/) do
+  visit current_url
+end
+
+Then(/^I try to reload page until contains "([^"]*)" text$/) do |arg1|
+  found = false
+  begin
+    Timeout.timeout(30) do
+      loop do
+        if page.has_content?(debrand_string(arg1))
+          found = true
+          break
+        end
+        visit current_url
+      end
+    end
+  rescue Timeout::Error
+    raise "'#{arg1}' cannot be found after wait and reload page"
+  end
+  fail unless found
+end

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -229,24 +229,6 @@ Then(/^all local repositories are disabled$/) do
     end
 end
 
-Then(/^I try to reload page until contains "([^"]*)" text$/) do |arg1|
-  found = false
-  begin
-    Timeout.timeout(30) do
-      loop do
-        if page.has_content?(debrand_string(arg1))
-          found = true
-          break
-        end
-        visit current_url
-      end
-    end
-  rescue Timeout::Error
-    raise "'#{arg1}' cannot be found after wait and reload page"
-  end
-  fail unless found
-end
-
 And(/^I follow the sle minion$/) do
  step %(I follow "#{$minion_fullhostname}")
 end
@@ -262,4 +244,87 @@ end
 Then(/^I should see "(.*?)" hostname$/) do |target|
  step %(I should see a "#{$minion_fullhostname}" text) if target == "sle-minion"
  step %(I should see a "#{$ceos_minion_fullhostname}" text) if target == "ceos-minion"
+end
+
+# salt formulas
+When(/^I manually install the "([^"]*)" formula on the server$/) do |package|
+  $server.run("zypper --non-interactive install -y #{package}-formula", false)
+end
+
+When(/^I check the "([^"]*)" formula$/) do |formula|
+  # Complicated code because the checkbox is not a <input type=checkbox> but an <i>
+  xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']"
+  if all(:xpath, xpath_query).any?
+    fail unless find(:xpath, xpath_query).click
+  else
+    xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']"
+    assert all(:xpath, xpath_query).any?, "Checkbox could not be found"
+  end
+end
+
+Then(/^the "([^"]*)" formula should be checked$/) do |formula|
+  # Complicated code because the checkbox is not a <input type=checkbox> but an <i>
+  xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']"
+  if all(:xpath, xpath_query).any?
+    fail "Checkbox is not checked"
+  end
+  xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']"
+  assert all(:xpath, xpath_query).any?, "Checkbox could not be found"
+end
+
+When(/^I select "([^"]*)" in (.*) field$/) do |value, box|
+  boxid = case box
+    when "timezone name"
+      "timezone\$name"
+    when "language"
+      "keyboard_and_language\$language"
+    when "keyboard layout"
+      "keyboard_and_language\$keyboard_layout"
+  end
+  select(value, :from => boxid)
+end
+
+Then(/^the timezone on "([^"]*)" should be "([^"]*)"$/) do |minion, timezone|
+  if minion == "sle-minion"
+    target = $minion
+  elsif minion == "ceos-minion"
+    target = $ceos_minion
+  else
+    fail "Invalid target"
+  end
+  output, _code = target.run("date +%Z")
+  fail unless output.strip == timezone
+end
+
+Then(/^the keymap on "([^"]*)" should be "([^"]*)"$/) do |minion, keymap|
+  if minion == "sle-minion"
+    target = $minion
+  elsif minion == "ceos-minion"
+    target = $ceos_minion
+  else
+    fail "Invalid target"
+  end
+  output, _code = target.run("cat /etc/vconsole.conf")
+  fail unless output.strip == "KEYMAP=#{keymap}"
+end
+
+Then(/^the language on "([^"]*)" should be "([^"]*)"$/) do |minion, language|
+  if minion == "sle-minion"
+    target = $minion
+  elsif minion == "ceos-minion"
+    target = $ceos_minion
+  else
+    fail "Invalid target"
+  end
+  output, _code = target.run("grep 'RC_LANG=' /etc/sysconfig/language")
+  fail unless output.strip == "RC_LANG=\"#{language}\""
+end
+
+When(/^I refresh the pillar data$/) do
+  $server.run("salt '#{$minion_ip}' saltutil.refresh_pillar")
+end
+
+Then(/^the pillar data for "([^"]*)" should be "([^"]*)"$/) do |key, value|
+  output, _code = $server.run("salt '#{$minion_ip}' pillar.get '#{key}'")
+  fail unless output.split("\n")[1].strip == value
 end

--- a/run_sets/testsuite.yml
+++ b/run_sets/testsuite.yml
@@ -82,6 +82,7 @@
 # this feature need another vm/client - features/salt_ssh.feature
 - features/salt_install_package.feature
 - features/salt_states_catalog.feature
+- features/salt_formulas.feature
 - features/minion_bootstrap.feature
 # Regression test
 - features/salt_regression_topsls.feature


### PR DESCRIPTION
Backport of salt formulas tests to 3.0.

Includes a cleanup of salt states left by sumaform.
Includes two new checks that I will submit in 3.1 as well.
Tested both in isolation and in context.