### PR TITLE
Fixed the installation of the "locale-formula" package

### DIFF
--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -248,7 +248,7 @@ end
 
 # salt formulas
 When(/^I manually install the "([^"]*)" formula on the server$/) do |package|
-  $server.run("zypper --non-interactive install -y #{package}-formula", false)
+  $server.run("zypper --non-interactive install -y #{package}-formula")
 end
 
 When(/^I check the "([^"]*)" formula$/) do |formula|


### PR DESCRIPTION
Now fails if "zypper install" fails.