### PR TITLE
Adding building steps. Build a basic image without server ip atm

### DIFF
--- a/features/docker_build_image.feature
+++ b/features/docker_build_image.feature
@@ -25,7 +25,7 @@ Feature:  Build Container images with SUSE Manager
   And I run "zypper -n --gpg-auto-import-keys ref" on "sle-minion"
   And I apply highstate on Sles minion
   Then I wait until "docker" service is up and running on "sle-minion"
-  # FIXME: add certicates.. 
+  # FIXME: add certicates..  SUMAFORM
   Scenario: Create an Image Store without credentials
   Given I am authorized as "admin" with password "admin"
   And I follow "Images" in the left menu
@@ -47,6 +47,16 @@ Feature:  Build Container images with SUSE Manager
 
   Scenario: Build a docker Image
   Given I am authorized as "admin" with password "admin"
-  # this maybe is another feature.
+  And I follow "Images" in the left menu
+  And I follow "Build" in the left menu
+  And I enter "opensuse" as "profileId"
+  # FIXME/WIP: this need implmentation
+  And I enter sle-minion hostname in Build Host
+  And I click on "submit-btn"
+
+
+  Scenario: Verify that the docker image was sucessefully created
+  Given I am authorized as "admin" with password "admin"
+
   Scenario: Create an Image Store with authentication
   Given I am authorized as "admin" with password "admin"

--- a/features/docker_build_image.feature
+++ b/features/docker_build_image.feature
@@ -25,7 +25,7 @@ Feature:  Build Container images with SUSE Manager
   And I run "zypper -n --gpg-auto-import-keys ref" on "sle-minion"
   And I apply highstate on Sles minion
   Then I wait until "docker" service is up and running on "sle-minion"
-  # FIXME: add certicates..  SUMAFORM
+
   Scenario: Create an Image Store without credentials
   Given I am authorized as "admin" with password "admin"
   And I follow "Images" in the left menu
@@ -42,6 +42,7 @@ Feature:  Build Container images with SUSE Manager
   And I follow "Create"
   And I enter "opensuse" as "label"
   And I select "galaxy-registry" from "imageStore"
+  And I select "1-MINION-TEST" from "activationKey"
   And I enter "https://gitlab.suse.de/galaxy/suse-manager-containers.git#:test-profile" as "path"
   And I click on "create-btn"
 
@@ -50,13 +51,12 @@ Feature:  Build Container images with SUSE Manager
   And I follow "Images" in the left menu
   And I follow "Build" in the left menu
   And I enter "opensuse" as "profileId"
-  # FIXME/WIP: this need implmentation
   And I enter sle-minion hostname in Build Host
   And I click on "submit-btn"
 
-
   Scenario: Verify that the docker image was sucessefully created
   Given I am authorized as "admin" with password "admin"
+  And I follow "Images" in the left menu
 
   Scenario: Create an Image Store with authentication
   Given I am authorized as "admin" with password "admin"

--- a/features/docker_build_image.feature
+++ b/features/docker_build_image.feature
@@ -51,7 +51,7 @@ Feature:  Build Container images with SUSE Manager
   And I follow "Images" in the left menu
   And I follow "Build" in the left menu
   And I enter "opensuse" as "profileId"
-  And I enter sle-minion hostname in Build Host
+  And I select sle-minion hostname in Build Host
   And I click on "submit-btn"
 
   Scenario: Verify that the docker image was sucessefully created

--- a/features/docker_build_image.feature
+++ b/features/docker_build_image.feature
@@ -35,12 +35,22 @@ Feature:  Build Container images with SUSE Manager
   And I enter "registry.suse.de" as "uri"
   And I click on "create-btn"
 
-  Scenario: Create an Image Profile
+  Scenario: Create a simple Image Profile 
   Given I am authorized as "admin" with password "admin"
   And I follow "Images" in the left menu
   And I follow "Profiles" in the left menu
   And I follow "Create"
-  And I enter "opensuse" as "label"
+  And I enter "suse_simply" as "label"
+  And I select "galaxy-registry" from "imageStore"
+  And I enter "https://gitlab.suse.de/galaxy/suse-manager-containers.git#:test-profile" as "path"
+  And I click on "create-btn"
+
+  Scenario: Create an Image Profile with activation-key
+  Given I am authorized as "admin" with password "admin"
+  And I follow "Images" in the left menu
+  And I follow "Profiles" in the left menu
+  And I follow "Create"
+  And I enter "suse_key" as "label"
   And I select "galaxy-registry" from "imageStore"
   And I select "1-MINION-TEST" from "activationKey"
   And I enter "https://gitlab.suse.de/galaxy/suse-manager-containers.git#:test-profile" as "path"
@@ -48,15 +58,14 @@ Feature:  Build Container images with SUSE Manager
 
   Scenario: Build a docker Image
   Given I am authorized as "admin" with password "admin"
-  And I follow "Images" in the left menu
-  And I follow "Build" in the left menu
-  And I enter "opensuse" as "profileId"
+  And I navigate to images build webpage
+  And I enter "suse_key" as "profileId"
   And I select sle-minion hostname in Build Host
   And I click on "submit-btn"
 
   Scenario: Verify that the docker image was sucessefully created
   Given I am authorized as "admin" with password "admin"
-  And I follow "Images" in the left menu
+  And I navigate to images webpage
 
   Scenario: Create an Image Store with authentication
   Given I am authorized as "admin" with password "admin"

--- a/features/step_definitions/docker_steps.rb
+++ b/features/step_definitions/docker_steps.rb
@@ -4,3 +4,11 @@
 And(/^I select sle-minion hostname in Build Host$/) do
   select($minion_fullhostname, :from => 'host')
 end
+
+And(/^I navigate to images webpage$/) do
+  visit("https://#{$server_fullhostname}/rhn/manager/cm/images")
+end
+
+And(/^I navigate to images build webpage$/) do
+  visit("https://#{$server_fullhostname}/rhn/manager/cm/build")
+end

--- a/features/step_definitions/docker_steps.rb
+++ b/features/step_definitions/docker_steps.rb
@@ -1,0 +1,6 @@
+# Copyright (c) 2017 Suse Linux
+# Licensed under the terms of the MIT license.
+
+And(/^I select sle-minion hostname in Build Host$/) do
+  select($minion_fullhostname, :from => 'host')
+end


### PR DESCRIPTION
### What this pr does:

enable basic building of docker images.
