### PR TITLE
Fix xpath for menu elements

### DIFF
--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -128,7 +128,7 @@ end
 When(/^I click Systems, under Systems node$/) do
   find(:xpath, "//div[@id=\"nav\"]/nav/ul/li[contains(@class, 'active')
        and contains(@class, 'open')
-       and contains(@class,'node')]/ul/li/a/span[contains(.,'Systems')]").click
+       and contains(@class,'node')]/ul/li/div/a/span[contains(.,'Systems')]").click
 end
 
 Given(/^I am not authorized$/) do


### PR DESCRIPTION
Because of [this PR](https://github.com/SUSE/spacewalk/pull/1044) we now have a different `xpath` for submenu elements. This PR addresses that changes.

You can see the new intermediate `tag` element as below:
![screenshot from 2017-03-22 13-10-59](https://cloud.githubusercontent.com/assets/7080830/24197299/5f939d76-0f01-11e7-9233-20a31ac7b404.png)
