### PR TITLE
Added tests for openSCAP audits on salt minions

### DIFF
--- a/features/salt_openscap_audit.feature
+++ b/features/salt_openscap_audit.feature
@@ -1,0 +1,59 @@
+# Copyright (c) 2017 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Use the openSCAP audit feature in SUSE Manager for a salt minion
+  In order to audit my salt minions
+  As an authorized user
+  I want to run openSCAP scans on them
+
+  Scenario: Schedule an audit job on the minion
+    Given I disable IPv6 forwarding on all interfaces of the SLE minion
+    And I am on the Systems overview page of this "sle-minion"
+    And I follow "Audit" in the content area
+    And I follow "Schedule" in the content area
+    When I enter "--profile Default" as "params"
+    And I enter "/usr/share/openscap/scap-yast2sec-xccdf.xml" as "path"
+    And I click on "Schedule"
+    Then I should see a "XCCDF scan has been scheduled" text
+    And I wait for the openSCAP audit to finish
+
+  Scenario: Check results of the audit job on the minion
+    Given I am on the Systems overview page of this "sle-minion"
+    And I follow "Audit" in the content area
+    When I follow "xccdf_org.open-scap_testresult_Default"
+    Then I should see a "Details of XCCDF Scan" text
+    And I should see a "Default" text
+    And I should see a "XCCDF Rule Results" text
+    And I should see a "pass" text
+    And I should see a "rule-" link
+
+  Scenario: Create a second, almost identical, audit job
+    Given I enable IPv6 forwarding on all interfaces of the SLE minion
+    And I am on the Systems overview page of this "sle-minion"
+    And I follow "Audit" in the content area
+    And I follow "Schedule" in the content area
+    When I enter "--profile Default" as "params"
+    And I enter "/usr/share/openscap/scap-yast2sec-xccdf.xml" as "path"
+    And I click on "Schedule"
+    Then I should see a "XCCDF scan has been scheduled" text
+    And I wait for the openSCAP audit to finish
+
+  Scenario: Compare audit results
+    Given I am on the Systems overview page of this "sle-minion"
+    And I follow "Audit" in the content area
+    And I follow "List Scans" in the content area
+    When I click on "Select All"
+    And I click on "Compare Selected Scans"
+    Then I should see a "XCCDF Rule Results" text
+    And I should see a "rule-sysctl-ipv6-all-forward" text
+
+  Scenario: Delete audit results and cleanup
+    Given I disable IPv6 forwarding on all interfaces of the SLE minion
+    And I am on the Systems overview page of this "sle-minion"
+    And I follow "Audit" in the content area
+    And I follow "List Scans" in the content area
+    When I click on "Select All"
+    And I click on "Remove Selected Scans"
+    And I click on "Confirm"
+    Then I should see a "2 SCAP Scan(s) deleted. 0 SCAP Scan(s) retained" text
+

--- a/features/step_definitions/command_steps.rb
+++ b/features/step_definitions/command_steps.rb
@@ -293,3 +293,26 @@ When(/^I click on "([^"]+)" for "([^"]+)"$/) do |arg1, arg2|
     end
   end
 end
+
+When(/^I disable IPv6 forwarding on all interfaces of the SLE minion$/) do
+  $minion.run("sysctl net.ipv6.conf.all.forwarding=0")
+end
+
+When(/^I enable IPv6 forwarding on all interfaces of the SLE minion$/) do
+  $minion.run("sysctl net.ipv6.conf.all.forwarding=1")
+end
+
+When(/^I wait for the openSCAP audit to finish$/) do
+  begin
+    Timeout.timeout(30) do
+      loop do
+        _output, code = $minion.run('ps aux | grep "oscap\ xccdf"', false)
+        unless code.zero?
+          break
+        end
+      end
+    end
+  rescue Timeout::Error
+    raise "process did not stop after several tries"
+  end
+end

--- a/run_sets/testsuite.yml
+++ b/run_sets/testsuite.yml
@@ -76,6 +76,7 @@
 - features/salt_install_package.feature
 - features/salt_states_catalog.feature
 - features/salt_formulas.feature
+- features/salt_openscap_audit.feature
 - features/salt_reboot_test.feature
 
 # salt regression


### PR DESCRIPTION
Tests:
* audit salt minions with openscap (currently fails, product bug: permissions problem)
* compare two audit reports
* delete audit reports (currently fails, product bug)

Tested both in isolation and within whole testsuite.