### PR TITLE
Better action pickup scenario (still disabled)

### DIFF
--- a/features/salt_action_pickedup.feature
+++ b/features/salt_action_pickedup.feature
@@ -1,34 +1,33 @@
 # Copyright (c) 2016 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Test the remote commands via salt
-  In Order to test action picked up state
+Feature: Test the state of salt remote commands
+  In order to be able to rely on command states
   As an authorized user
-  I want to verify that the remote command show status picked up as long as the command is running
+  I want the remote commands to go through picked up and completed states
 
-  Scenario: Run a remote command from the systems overview page (pickedup-test)
+  Scenario: Schedule a long command on the sle minion
     Given I am authorized as "testing" with password "testing"
-    And I follow "Systems"
-    Then I follow this minion link
-    When I follow "Remote Command" in the content area
-    And I enter as remote command this script in
-      """
-      #!/bin/bash
-      while [ ! -f /tmp/PICKED-UP.test ]
-      do
-        sleep 1
-      done
-      rm /tmp/PICKED-UP.test
-      """
+    And I am on the System Overview page
+    When I follow this minion link
+    And I follow "Remote Command" in the content area
+    And I enter as remote command a script to watch a picked-up test file
     And I click on "Schedule"
     Then I should see a "Remote Command has been scheduled successfully" text
-    And I follow "Events" in the content area
+
+  Scenario: Check that the long command gets picked up
+    Given I am on the Systems overview page of this "sle-minion"
+    When I follow "Events" in the content area
     And I follow "History" in the content area
     And I wait for "1" seconds
-    Then I follow first "Run an arbitrary script scheduled by testing" in the content area
-    And I should see a "This action's status is: Picked Up" text
-    And I create picked-up test file on sle minion
-    And I wait for "6" seconds  
+    And I follow first "Run an arbitrary script scheduled by testing" in the content area
+    Then I should see a "This action's status is: Picked Up" text
+
+  Scenario: Check that the long command can complete
+    Given I am on the Systems overview page of this "sle-minion"
+    When I create picked-up test file on sle minion
+    And I wait for "6" seconds
+    When I follow "Events" in the content area
     And I follow "History" in the content area
-    Then I follow first "Run an arbitrary script scheduled by testing" in the content area
-    And I should see a "This action's status is: Completed" text
+    And I follow first "Run an arbitrary script scheduled by testing" in the content area
+    Then I should see a "This action's status is: Completed" text

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -237,8 +237,21 @@ And(/^I follow the sle minion$/) do
  step %(I follow "#{$minion_fullhostname}")
 end
 
-And(/^I create picked-up test file on sle minion$/) do
-  $minion.run("touch /tmp/PICKED-UP.test")
+When(/^I enter as remote command a script to watch a picked-up test file$/) do
+  steps %(
+    When I enter as remote command this script in
+      """
+      #!/bin/bash
+      while [ ! -f /tmp/PICKED-UP-#{$$}.test ]
+      do
+        sleep 1
+      done
+      rm /tmp/PICKED-UP-#{$$}.test
+      """)
+end
+
+When(/^I create picked-up test file on sle minion$/) do
+  $minion.run("touch /tmp/PICKED-UP-#{$$}.test")
 end
 
 Then(/^I should see "(.*?)" hostname$/) do |minion|

--- a/run_sets/testsuite.yml
+++ b/run_sets/testsuite.yml
@@ -72,7 +72,7 @@
 - features/salt_software_states.feature
 - features/salt_pkgset_beacon.feature
 - features/salt_remote_cmds.feature
-# - features/salt_action_pickedup.feature NEED FIX. Unstable test
+# - features/salt_action_pickedup.feature Test does not work because actions are not sorted in chronological order
 - features/salt_install_package.feature
 - features/salt_states_catalog.feature
 - features/salt_formulas.feature


### PR DESCRIPTION
The fix puts the PID of the remote command into the test file name, to avoid race between several tests.

But the real problem is that the GUI does not sort the actions by chronological order, so picking up the "first" action is wrong. I don't see a solution to this unless we change the GUI.

These changes can safely be merged though as the cucumber feature is still commented out...