### PR TITLE
Adds cucumber tests for Salt presence ping mechanism

### DIFF
--- a/features/salt_software_states.feature
+++ b/features/salt_software_states.feature
@@ -73,3 +73,19 @@ Feature: Check the Salt package state UI
     And I should see a "milkyway-dummy" text
     And I should see a "andromeda-dummy" text
     And I should see a "virgo-dummy" text
+
+  Scenario: Test Salt presence ping mechanism on active minion
+    Given I am on the Systems overview page of this "sle-minion"
+    Then I follow "States" in the content area
+    And I follow "Highstate" in the content area
+    And I wait for "6" seconds
+    And I should see "pkg_removed" in the textarea
+
+  Scenario: Test Salt presence ping mechanism on unreachable minion
+    Given I am on the Systems overview page of this "sle-minion"
+    Then I follow "States" in the content area
+    And I run "pkill salt-minion" on "sle-minion"
+    And I follow "Highstate" in the content area
+    And I wait for "6" seconds
+    And I run "rcsalt-minion restart" on "sle-minion"
+    And I should see "No reply from minion" in the textarea

--- a/features/salt_software_states.feature
+++ b/features/salt_software_states.feature
@@ -79,7 +79,7 @@ Feature: Check the Salt package state UI
     Then I follow "States" in the content area
     And I follow "Highstate" in the content area
     And I wait for "6" seconds
-    And I should see "pkg_removed" in the textarea
+    And I should see "pkg_removed" loaded in the textarea
 
   Scenario: Test Salt presence ping mechanism on unreachable minion
     Given I am on the Systems overview page of this "sle-minion"
@@ -88,4 +88,4 @@ Feature: Check the Salt package state UI
     And I follow "Highstate" in the content area
     And I wait for "6" seconds
     And I run "rcsalt-minion restart" on "sle-minion"
-    And I should see "No reply from minion" in the textarea
+    And I should see "No reply from minion" loaded in the textarea

--- a/features/step_definitions/content_steps.rb
+++ b/features/step_definitions/content_steps.rb
@@ -32,6 +32,10 @@ Then(/^I should see "([^"]*)" in the textarea$/) do |arg1|
   end
 end
 
+Then(/^I should see "([^"]*)" loaded in the textarea$/) do |arg1|
+  fail unless first('textarea').value.include?(debrand_string(arg1))
+end
+
 Then(/^I should see that this system has been deleted$/) do
   system_id = client_system_id_to_i
   step %(I should see a "System profile #{system_id} has been deleted." text)


### PR DESCRIPTION
This PR adds new tests to check if the presence ping mechanism is working for synchronous calls and preventing from blocking when there is an unreachable minion.

I added a new step definition to check for a value inside a dynamically loaded on the textarea. This is because the current `I should see ... in the textarea` is not working in this particular case where data is injected some time after the page is loaded.

Once this PR gets merged on `master` I'll also cherry-pick it to `manager30` branch.