### PR TITLE
Fix possible race condition

### DIFF
--- a/features/salt_openscap_audit.feature
+++ b/features/salt_openscap_audit.feature
@@ -15,6 +15,7 @@ Feature: Use the openSCAP audit feature in SUSE Manager for a salt minion
     And I enter "/usr/share/openscap/scap-yast2sec-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
+    And I wait for "5" seconds
     And I wait for the openSCAP audit to finish
 
   Scenario: Check results of the audit job on the minion
@@ -36,6 +37,7 @@ Feature: Use the openSCAP audit feature in SUSE Manager for a salt minion
     And I enter "/usr/share/openscap/scap-yast2sec-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
+    And I wait for "5" seconds
     And I wait for the openSCAP audit to finish
     And I disable IPv6 forwarding on all interfaces of the SLE minion
 


### PR DESCRIPTION
It was possible that we tested that openscap audit was finished even before
it started ;-) .