### PR TITLE
Reset locale settings to their original values

### DIFF
--- a/features/salt_formulas.feature
+++ b/features/salt_formulas.feature
@@ -35,7 +35,7 @@ Feature: Use salt formulas
      And I click on "Save Formula"
      Then I should see a "Formula saved!" text
 
-  Scenario: Apply the formula via the highstate
+  Scenario: Apply the parametrized formula via the highstate
      Given I am on the Systems overview page of this "sle-minion"
      When I follow "Formula Catalog" in the content area
      And I follow "Formulas" in the content area
@@ -51,3 +51,22 @@ Feature: Use salt formulas
      Then the pillar data for "timezone:name" should be "Etc/GMT-5"
      And the pillar data for "keyboard_and_language:keyboard_layout" should be "French (Canada)"
      And the pillar data for "keyboard_and_language:language" should be "French"
+
+  Scenario: Reset the formula on the minion
+     Given I am on the Systems overview page of this "sle-minion"
+     When I follow "Formula Catalog" in the content area
+     And I follow "Locale" in the content area
+     And I click on "Clear values" and confirm
+     And I click on "Save Formula"
+     Then I should see a "Formula saved!" text
+
+  Scenario: Apply the reset formula via the highstate
+     Given I am on the Systems overview page of this "sle-minion"
+     When I follow "Formula Catalog" in the content area
+     And I follow "Formulas" in the content area
+     And I click on "Apply Highstate"
+     Then I should see a "Applying the highstate has been scheduled." text
+     And I wait for "40" seconds
+     And the timezone on "sle-minion" should be "CET"
+     And the keymap on "sle-minion" should be "us.map.gz"
+     And the language on "sle-minion" should be "en_US.UTF-8"

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -56,6 +56,14 @@ When(/^I click on "([^"]*)"$/) do |arg1|
   end
 end
 #
+# Click on a button and confirm in alert box
+When(/^I click on "([^"]*)" and confirm$/) do |arg1|
+  accept_alert do
+    step %(I click on "#{arg1}")
+    sleep 1
+  end
+end
+#
 # Click on a link
 #
 When(/^I follow "([^"]*)"$/) do |text|

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -430,7 +430,9 @@ Then(/^the timezone on "([^"]*)" should be "([^"]*)"$/) do |minion, timezone|
     fail "Invalid target"
   end
   output, _code = target.run("date +%Z")
-  fail unless output.strip == timezone
+  result = output.strip
+  result = "CET" if result == "CEST"
+  fail unless result == timezone
 end
 
 Then(/^the keymap on "([^"]*)" should be "([^"]*)"$/) do |minion, keymap|
@@ -453,8 +455,8 @@ Then(/^the language on "([^"]*)" should be "([^"]*)"$/) do |minion, language|
   else
     fail "Invalid target"
   end
-  output, _code = target.run("grep 'LANG=' /etc/locale.conf")
-  fail unless output.strip == "LANG=#{language}"
+  output, _code = target.run("grep 'RC_LANG=' /etc/sysconfig/language")
+  fail unless output.strip == "RC_LANG=\"#{language}\""
 end
 
 When(/^I refresh the pillar data$/) do


### PR DESCRIPTION
Get back from Etc/-05 to CET (or CEST, in summer), because it can be puzzling to have UTC+5 dates displayed - and also because tests should be idempotent

Take profit of the occasion to test "Clear values" button in formulas page.