### PR TITLE
Manager30 rebootmachines

### DIFF
--- a/features/reboot_machines.feature
+++ b/features/reboot_machines.feature
@@ -1,0 +1,7 @@
+# Copyright (c) 2017 SUSE LLC                                                                                                                             
+# Licensed under the terms of the MIT license. 
+
+Feature: I reboot the sles vms
+
+Scenario: Reboot sles vms
+  When I reboot sles vms

--- a/features/step_definitions/command_steps.rb
+++ b/features/step_definitions/command_steps.rb
@@ -2,6 +2,16 @@
 # Licensed under the terms of the MIT license.
 require 'timeout'
 
+Then(/^I reboot sles vms$/) do
+  # reboot sles based vms since they were updated, including suma server
+  vms_to_reboot = [$ssh_minion_fullhostname, $minion_fullhostname, $client_fullhostname, ENV['TESTHOST']]
+  vms_to_reboot.each do |vm|
+    sshcmd("shutdown -r -t 30 > /dev/null 2> /dev/null & ", host: vm)
+    sleep 30
+    checkRestart(vm, 120)
+  end
+end
+
 def checkShutdown(host, time_out)
   cmd = "ping -c1 #{host}"
   Timeout.timeout(time_out) do

--- a/run_sets/testsuite.yml
+++ b/run_sets/testsuite.yml
@@ -1,4 +1,5 @@
 --- # List of features for a full test run
+- features/reboot_machines.feature
 - features/init_user_create.feature
 - features/setup_proxy.feature
 - features/running.feature


### PR DESCRIPTION
this is part of a sumaform / testsuite change.  Sumaform will (soon) patch machines with sle test updates which will require a reboot(from kernel/glibc).   So they will now be restarted in the test suite first, before the rest of the tests run.