### PR TITLE
Feature "minion_datacenter" broken if IPv6 not working, disabling for now

### DIFF
--- a/run_sets/testsuite.yml
+++ b/run_sets/testsuite.yml
@@ -91,8 +91,10 @@
 
 ### Scalability tests (after debug always)
 - features/docker_xmlrpc.feature
-- features/minion_datacenter.feature
-## smdba and change password feature always put them at the end of the testsuite.
+# - features/minion_datacenter.feature
+### Disabled: does not work if IPv6 broken
+
+## alway put smdba and change password features at the end of the testsuite.
 - features/change_password.feature
 
 # sync channels in background


### PR DESCRIPTION
Test fails with

`http://centos.s.uw.edu/centos/6/os/x86_64/Packages/gpm-libs-1.20.6-12.el6.x86_64.rpm:
[Errno 14] PYCURL ERROR 7 - "Failed to connect to 2607:4000:200:4b::120: Network is unreachable"`

Disabling it for now. Long term solution is either to add "ip_resolve=4" to /etc/yum/yum.conf, or (better) to make sure that IPv6 works on our test machines.