### PR TITLE
Accept repository names to be surrounded by whitespace inside <a>

### DIFF
--- a/features/create_repository.feature
+++ b/features/create_repository.feature
@@ -36,7 +36,7 @@ Feature: Adding repository to a channel
     And I follow "Overview" in the left menu
     And I follow "Test-Channel-x86_64"
     And I follow "Repositories" in the content area
-    When I select the "Test-Repository-x86_64" repo
+    When I select the "Test-Repository-x86_64" repo and delete all whitespaces
     And I click on "Update Repositories"
     Then I should see a "Test-Channel-x86_64 repository information was successfully updated" text
 
@@ -65,7 +65,7 @@ Feature: Adding repository to a channel
     And I follow "Overview" in the left menu
     And I follow "Test-Channel-i586"
     And I follow "Repositories" in the content area
-    When I select the "Test-Repository-i586" repo
+    When I select the "Test-Repository-i586" repo and delete all whitespaces
     And I click on "Update Repositories"
     Then I should see a "Test-Channel-i586 repository information was successfully updated" text
 

--- a/features/step_definitions/content_steps.rb
+++ b/features/step_definitions/content_steps.rb
@@ -183,7 +183,8 @@ Then(/^I select the "([^"]*)" repo $/) do |arg1|
     first('input[type=checkbox]').set(true)
   end
 end
-
+# HACK: this step while cancel all whitespaces and also the steps
+# inside the repo name
 Then(/^I select the "([^"]*)" repo and delete all whitespaces$/) do |arg1|
   within(:xpath, "//a[normalize-space()='#{arg1}']/../..") do
     first('input[type=checkbox]').set(true)

--- a/features/step_definitions/content_steps.rb
+++ b/features/step_definitions/content_steps.rb
@@ -179,7 +179,7 @@ Then(/^I should see a "([^"]*)" button in "([^"]*)" form$/) do |arg1, arg2|
 end
 
 Then(/^I select the "([^"]*)" repo $/) do |arg1|
-  within(:xpath, "//a[normalize-space()='#{arg1}']/../..") do
+  within(:xpath, "//a[text()='#{arg1}']/../..") do
     first('input[type=checkbox]').set(true)
   end
 end

--- a/features/step_definitions/content_steps.rb
+++ b/features/step_definitions/content_steps.rb
@@ -179,7 +179,7 @@ Then(/^I should see a "([^"]*)" button in "([^"]*)" form$/) do |arg1, arg2|
 end
 
 Then(/^I select the "([^"]*)" repo$/) do |arg1|
-  within(:xpath, "//a[text()='#{arg1}']/../..") do
+  within(:xpath, "//a[normalize-space()='#{arg1}']/../..") do
     first('input[type=checkbox]').set(true)
   end
 end

--- a/features/step_definitions/content_steps.rb
+++ b/features/step_definitions/content_steps.rb
@@ -178,7 +178,13 @@ Then(/^I should see a "([^"]*)" button in "([^"]*)" form$/) do |arg1, arg2|
   end
 end
 
-Then(/^I select the "([^"]*)" repo$/) do |arg1|
+Then(/^I select the "([^"]*)" repo $/) do |arg1|
+  within(:xpath, "//a[normalize-space()='#{arg1}']/../..") do
+    first('input[type=checkbox]').set(true)
+  end
+end
+
+Then(/^I select the "([^"]*)" repo and delete all whitespaces$/) do |arg1|
   within(:xpath, "//a[normalize-space()='#{arg1}']/../..") do
     first('input[type=checkbox]').set(true)
   end


### PR DESCRIPTION
Step ```When I select the "Test-Repository-x86_64" repo``` was failing because of new indentation.

```
      <a href="/rhn/channels/manage/repos/RepoEdit.do?id=500">
            Test-Repository-x86_64
      </a>
```
was not recognized as ```Test-Repository-x86_64```, because of the whitespace surrounding it.

The new XPath code uses ```normalize-space()``` instead of ```text()```. It is not a perfect solution, because the leading and trailing spaces are not only trimmed, but spaces inside the content are also collapsed. As a consequence, after this change, it might be needed to normalize spaces inside the names of repositories.
