### PR TITLE
Restoring a unified maximum timeout

### DIFF
--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -25,7 +25,7 @@ Given(/^that the master can reach this client$/) do
     start = Time.now
     # 300 is the default 1st keepalive interval for the minion
     # where it realizes the connection is stuck
-    Timeout.timeout(DEFAULT_TIMEOUT + 300) do
+    Timeout.timeout(DEFAULT_TIMEOUT) do
       # only try 3 times
       3.times do
         @output = sshcmd("salt #{$minion_hostname} test.ping", ignore_err: true)
@@ -305,7 +305,7 @@ end
 
 When(/^I click on run$/) do
   begin
-    Timeout.timeout(DEFAULT_TIMEOUT + 400) do
+    Timeout.timeout(DEFAULT_TIMEOUT) do
       loop do
         begin
           find('button#run').click
@@ -757,7 +757,7 @@ end
 Given(/^the salt-master can reach "([^"]*)"$/) do |minion|
   begin
     # where it realizes the connection is stuck
-    Timeout.timeout(DEFAULT_TIMEOUT + 300) do
+    Timeout.timeout(DEFAULT_TIMEOUT) do
       # only try 3 times
       3.times do
         if minion == "sle-minion"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -31,7 +31,10 @@ end
 
 # basic support for rebranding of strings in the UI
 BRANDING = ENV['BRANDING'] || 'suse'
-DEFAULT_TIMEOUT = 200
+
+# 10 minutes maximal wait before giving up
+# the tests return much before that delay in case of success
+DEFAULT_TIMEOUT = 600
 
 # Returns current url
 def current_url


### PR DESCRIPTION
Set to a generous 10 minutes
The tests are suppose to return much earlier in case of success

(backport for 3.1 of same pull request for head)