### PR TITLE
Prevent spurious failures for presence ping test

### DIFF
--- a/features/salt_software_states.feature
+++ b/features/salt_software_states.feature
@@ -84,7 +84,7 @@ Feature: Check the Salt package state UI
     Then I follow "States" in the content area
     And I follow "Highstate" in the content area
     And I wait for "6" seconds
-    And I should see a "pkg_removed" text in element "highstate"
+    And I should see a "pkg_removed" or "running as PID" text in element "highstate"
 
   Scenario: Test Salt presence ping mechanism on unreachable minion
     Given I am on the Systems overview page of this "sle-minion"

--- a/features/step_definitions/content_steps.rb
+++ b/features/step_definitions/content_steps.rb
@@ -114,6 +114,12 @@ Then(/^I should see a "([^"]*)" text in element "([^"]*)"$/) do |arg1, arg2|
   end
 end
 
+Then(/^I should see a "([^"]*)" or "([^"]*)" text in element "([^"]*)"$/) do |arg1, arg2, arg3|
+  within(:xpath, "//div[@id=\"#{arg3}\" or @class=\"#{arg3}\"]") do
+    fail if !has_content?(debrand_string(arg1)) && !has_content?(debrand_string(arg2))
+  end
+end
+
 Then(/^I should see a "([^"]*)" link in "([^"]*)" "([^"]*)"$/) do |arg1, arg2, arg3|
   fail unless page.has_xpath?("//#{arg2}[@id='#{arg3}' or @class='#{arg3}']/a[text()='#{debrand_string(arg1)}']")
 end


### PR DESCRIPTION
This should prevent the spurious failures caused in case an state is being executed when performing the presence ping test.

On such cases we don't expect to get the actual response from `state.show_highstate` but a response from the minion like: 

```
- The function "state.apply" is running as PID 8710 and was started at 2017, Jul 05 12:11:54.266463 with jid 20170705121154266463
```

Getting either any of both responses is a valid scenario as the minion is actually responding.