### PR TITLE
updated button text for activation key tabs

### DIFF
--- a/features/create_activationkey.feature
+++ b/features/create_activationkey.feature
@@ -68,7 +68,7 @@ Feature: Create an activation key
     And I click on "Create Activation Key"
     And I follow "Packages"
     And I enter "man" as "packages"
-    And I click on "Update Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test PKG Key x86_64 has been modified." text
     And I should see a "Details" link
     And I should see a "Child Channels" link
@@ -88,7 +88,7 @@ Feature: Create an activation key
     And I click on "Create Activation Key"
     And I follow "Packages"
     And I enter "man" as "packages"
-    And I click on "Update Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test PKG Key i586 has been modified." text
     And I should see a "Details" link
     And I should see a "Child Channels" link

--- a/features/custom_system_info.feature
+++ b/features/custom_system_info.feature
@@ -28,7 +28,7 @@ Feature: Test custom system info key value pairs
     And I follow "Create Value"
     And I follow "key-label"
     And I enter "key-value" as "value"
-    And I click on "Update Key"
+    And I click on "Update Activation Key"
     Then I should see a "key-label" text
     And I should see a "key-value" text
     And I should see a "Edit this value" link
@@ -39,7 +39,7 @@ Feature: Test custom system info key value pairs
     And I follow "Edit this value"
     And I should see a "Edit Custom Value" text
     And I enter "key-value-edited" as "value"
-    And I click on "Update Key"
+    And I click on "Update Activation Key"
     Then I should see a "key-label" text
     And I should see a "key-value-edited" text
     And I should see a "Edit this value" link
@@ -49,7 +49,7 @@ Feature: Test custom system info key value pairs
     And I follow "key-label"
     And I should see this client as link
     And I enter "key-desc-edited" as "description"
-    And I click on "Update Key"
+    And I click on "Update Activation Key"
     Then I should see a "key-label" link
     And I should see a "key-desc-edited" text
 

--- a/features/docker_build_image.feature
+++ b/features/docker_build_image.feature
@@ -37,7 +37,7 @@ Feature:  Build Container images with SUSE Manager. Basic image
   And I click on "Create Activation Key"
   And I follow "Packages"
   And I enter "orion-dummy perseus-dummy" as "packages"
-  And I click on "Update Key"
+  And I click on "Update Activation Key"
   Then I should see a "Activation key Docker testing has been modified" text
 
   Scenario: Assign to the sles-minion the property container build host 

--- a/features/minion_bootstrap.feature
+++ b/features/minion_bootstrap.feature
@@ -63,7 +63,7 @@ Feature: register a salt-minion via bootstrap
     And I click on "Create Activation Key"
     And I follow "Packages"
     And I enter "orion-dummy perseus-dummy" as "packages"
-    And I click on "Update Key"
+    And I click on "Update Activation Key"
     Then I should see a "Activation key Minion testing has been modified" text
 
   Scenario: bootstrap a sles minion with an activation-key


### PR DESCRIPTION
I changed the text on a couple of the tabs for the activation key buttons from "Update Key" to "Update Activation Key"