### PR TITLE
Fix: increase timeout when issuing cmd.run

### DIFF
--- a/features/salt_ssh.feature
+++ b/features/salt_ssh.feature
@@ -4,14 +4,14 @@
 Feature: 1) Bootstrap a new salt host via salt-ssh
    verify functionality: script, remote cmds, packages install, channel subscription.
   2) delete the ssh-minion
-  3) bootstap a ssh-minion tunneled by ssh-reverse. 
+  3) bootstap a ssh-minion tunneled by ssh-reverse.
      verify functionality: script, remote cmds, packages install, channel subscription.
      verify tunnel proprety: repo 1233 port, and installation of pkg only via server.
 
   Scenario: No Salt Package and service are running on Minion
     Given no Salt packages are installed on remote "ssh-minion"
     And remote minion host is not registered in Spacewalk
-    
+
   Scenario: Bootstrap a system via salt-ssh
     Given I am authorized
     When I follow "Salt"
@@ -48,7 +48,7 @@ Feature: 1) Bootstrap a new salt host via salt-ssh
     And I should see a "Remote Commands" text
     Then I enter command "rpm -q salt-minion"
     And I click on preview
-    And I wait for "10" seconds
+    And I wait for "20" seconds
     And I click on run
     And I wait for "10" seconds
     And I expand the results for "ssh-minion"
@@ -86,7 +86,7 @@ Feature: 1) Bootstrap a new salt host via salt-ssh
   Scenario: No Salt Package and service are running on Minion
     Given no Salt packages are installed on remote "ssh-minion"
     And remote minion host is not registered in Spacewalk
-  
+
   Scenario: Bootstrap a system via salt-ssh with reverse ssh-tunnel
     Given I am authorized
     When I follow "Salt"
@@ -124,7 +124,7 @@ Feature: 1) Bootstrap a new salt host via salt-ssh
     And I should see a "Remote Commands" text
     Then I enter command "rpm -q salt-minion"
     And I click on preview
-    And I wait for "10" seconds
+    And I wait for "20" seconds
     And I click on run
     And I wait for "10" seconds
     And I expand the results for "ssh-minion"


### PR DESCRIPTION
It happens sometimes that we get a failure in these two scenarios,
because we are waiting for the command to reach all the minions.
A first workaround (this pr) increases the time we are waiting for the
button to appear.