### PR TITLE
Using random salt-thin dir for each salt-ssh call

### DIFF
--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -500,7 +500,7 @@ Then(/^the pillar data for "([^"]*)" should be "([^"]*)" on "([^"]*)"$/) do |key
   elsif minion == "ssh-minion"
     target = $ssh_minion_ip
     cmd = "salt-ssh"
-    extra_cmd = "-i --roster-file=/tmp/tmp_roster_tests"
+    extra_cmd = "-i --roster-file=/tmp/tmp_roster_tests -w -W"
     $server.run("printf '#{target}:\n  host: #{target}\n  user: root\n  passwd: linux' > /tmp/tmp_roster_tests")
   else
     fail "Invalid target"


### PR DESCRIPTION
This avoid a race condition when multiple salt-ssh calls are trying to deploy salt-thin using the same salt-thin dir. The "-w" parameter would also wipe the deployed salt-thin after each salt-ssh execution.

This will fix the spurious failure of "# Scenario: Parametrize the formula on the minion".

This would go also to `head` branch.