### PR TITLE
Head idempotent: Schedule errata-cache and channel-repo data just after sync repo

### DIFF
--- a/features/CVE_ID_new_syntax.feature
+++ b/features/CVE_ID_new_syntax.feature
@@ -4,10 +4,10 @@
 Feature: Check if new CVE-ID syntax is working with SUSE Manager
   In Order to check if the new CVE-ID syntax is working with SUSE Manager
   As the testing user
-  I want to see the erratums in the web page with a long CVE ID
+  I want to see the patches in the web page with a long CVE ID
 
-  Scenario: check perseus-dummy-7891 errata
-    Given I am on the errata page
+  Scenario: check perseus-dummy-7891 patches
+    Given I am on the patches page
     When I follow "All" in the left menu
     And I follow "perseus-dummy-7891"
     Then I should see a "perseus-dummy-7891 - Security Advisory" text
@@ -22,7 +22,7 @@ Feature: Check if new CVE-ID syntax is working with SUSE Manager
     And I should have 'reference.*http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-99781' in the patch metadata
 
   Scenario: Search for CVE ID with the new format
-    Given I am on the errata page
+    Given I am on the patches page
     And I follow "Advanced Search"
     When I enter "CVE-1999-12345" as "search_string" in the content area
     And I click on "Search"

--- a/features/baremetal_test.feature
+++ b/features/baremetal_test.feature
@@ -72,7 +72,7 @@ Feature: Test Bare-metal discovery
   Scenario: check tabs Schedule and Power Management for sle-client
     Given I am on the Systems overview page of this "sle-client"
     When I follow "Provisioning" in the content area
-    Then I should see a "Kickstart" link in the content area
+    Then I should see a "Autoinstallation" link in the content area
     And I should not see a "Snapshots" link in the content area
     And I should not see a "Snapshot Tags" link in the content area
     And I should see a "Power Management" link in the content area
@@ -93,7 +93,7 @@ Feature: Test Bare-metal discovery
     And I should see a "power management operations" link in the content area
     And I should see a "Delete" link in the content area
     And I should see a "Migrate" link in the content area
-    And I should not see a "Errata" link in the content area
+    And I should not see a "Patches" link in the content area
     And I should not see a "Packages" link in the content area
     And I should see a "Groups" link in the content area
     And I should not see a "Channels" link in the content area

--- a/features/check_errata_npn.feature
+++ b/features/check_errata_npn.feature
@@ -1,19 +1,19 @@
 # Copyright (c) 2015 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Check errata
-  In Order to check if the errata import was successfull
+Feature: Check patches
+  In Order to check if the patches import was successfull
   As the testing user
-  I want to see the erratums in the web page including the packages
+  I want to see the patches in the web page including the packages
 
-  Scenario: check all errata exists
-    Given I am on the errata page
+  Scenario: check all patches exists
+    Given I am on the patches page
     When I follow "Relevant" in the left menu
     Then I should see an update in the list
     And I should see a "virgo-dummy-3456" link
 
-  Scenario: check sles-release-6789 errata
-    Given I am on the errata page
+  Scenario: check sles-release-6789 patches
+    Given I am on the patches page
     And I follow "andromeda-dummy-6789"
     Then I should see a "andromeda-dummy-6789 - Bug Fix Advisory" text
     And I should see a "Test update for andromeda-dummy" text
@@ -21,8 +21,8 @@ Feature: Check errata
     And I should see a "Test-Channel-i586" link
     And I should see a "reboot_suggested" text
 
-  Scenario: check sles-release-6789 errata packages
-    Given I am on the errata page
+  Scenario: check sles-release-6789 patches packages
+    Given I am on the patches page
     And I follow "andromeda-dummy-6789"
     And I follow "Packages"
     Then I should see a "Test-Channel-x86_64" link
@@ -30,11 +30,11 @@ Feature: Check errata
     And I should see a "sha256:3bb3a56e6654f14300ab815c3f6e2af848874c829541b4e1b342262bb2f72d30" text
     And I should see a "andromeda-dummy-2.0-1.1-noarch" link
 
-  Scenario: check relevant errata for this client
+  Scenario: check relevant patches for this client
     Given I am on the Systems overview page of this "sle-client"
     When I follow "Software" in the content area
-    And I follow "Errata" in the content area
-    Then I should see a "Relevant Errata" text
+    And I follow "Patches" in the content area
+    Then I should see a "Relevant Patches" text
     And I should see a "Test update for virgo-dummy" text
 
   Scenario: regenerate search index for later tests

--- a/features/check_registration.feature
+++ b/features/check_registration.feature
@@ -32,7 +32,7 @@ Feature: Check client registration
     And I should see a "Provisioning" link in the content area
     And I should see a "Groups" link in the content area
     And I should see a "Events" link in the content area
-    And I should see a "Errata" link in the content area
+    And I should see a "Patches" link in the content area
     And I should see a "Packages" link in the content area
     And I should see a "Software Channels" link in the content area
     And I should see a "List / Remove" link
@@ -80,7 +80,7 @@ Feature: Check client registration
     And I should see a "Provisioning" link in the content area
     And I should see a "Groups" link in the content area
     And I should see a "Events" link in the content area
-    And I should see a "Kickstart" link in the content area
+    And I should see a "Autoinstallation" link in the content area
     And I should see a "Snapshots" link in the content area
     And I should see a "Snapshot Tags" link in the content area
     And I should see a "Schedule" link in the content area
@@ -123,7 +123,7 @@ Feature: Check client registration
     And I should see a "Management" text
     And I should see a "receive_notifications" element in "systemDetailsForm" form
     And I should see a "summary" element in "systemDetailsForm" form
-    And I should see a "autoerrataupdate" element in "systemDetailsForm" form
+    And I should see a "autopatchesupdate" element in "systemDetailsForm" form
     And I should see a "description" element in "systemDetailsForm" form
     And I should see a "address" element in "systemDetailsForm" form
     And I should see a "city" element in "systemDetailsForm" form

--- a/features/clone_channel_npn.feature
+++ b/features/clone_channel_npn.feature
@@ -4,9 +4,9 @@
 Feature: Clone a Channel
   In Order to validate the channel cloning feature
   As a testing user
-  I want to clone a channel with errata, without errata and with selected erratas
+  I want to clone a channel with patches, without patches and with selected patchess
 
-  Scenario: Clone a Channel without errata
+  Scenario: Clone a Channel without patches
     Given I am on the manage software channels page
     When I follow "Clone Channel"
     And I select "Test-Channel-x86_64" as the origin channel
@@ -17,14 +17,14 @@ Feature: Clone a Channel
     And I click on "Clone Channel"
     Then I should see a "Clone of Test-Channel-x86_64" text
 
-  Scenario: Check, that this channel has no erratas
+  Scenario: Check, that this channel has no patchess
     Given I am on the manage software channels page
     And I follow "Clone of Test-Channel-x86_64"
-    When I follow "Errata" in the content area
-    And I follow "List/Remove Errata"
-    Then I should see a "There are no errata associated with this channel." text
+    When I follow "Patches" in the content area
+    And I follow "List/Remove Patches"
+    Then I should see a "There are no patches associated with this channel." text
 
-  Scenario: Clone a Channel with errata
+  Scenario: Clone a Channel with patches
     Given I am on the manage software channels page
     When I follow "Clone Channel"
     And I select "Test-Channel-x86_64" as the origin channel
@@ -35,37 +35,37 @@ Feature: Clone a Channel
     And I click on "Clone Channel"
     Then I should see a "Clone 2 of Test-Channel-x86_64" text
 
-  Scenario: Check, that this channel has erratas
+  Scenario: Check, that this channel has patchess
     Given I am on the manage software channels page
     And I follow "Clone 2 of Test-Channel-x86_64"
-    When I follow "Errata" in the content area
-    And I follow "List/Remove Errata"
+    When I follow "Patches" in the content area
+    And I follow "List/Remove Patches"
     Then I should see a "CL-hoag-dummy-7890" link
     And I should see a "CL-virgo-dummy-3456" link
     And I should see a "CL-milkyway-dummy-2345" link
     And I should see a "CL-andromeda-dummy-6789" link
 
-  Scenario: Clone a Channel with selected errata
+  Scenario: Clone a Channel with selected patches
     Given I am on the manage software channels page
     When I follow "Clone Channel"
     And I select "Test-Channel-x86_64" as the origin channel
     And I choose "select"
     And I click on "Clone Channel"
     And I should see a "Create Software Channel" text
-    And I should see a "Select errata" text
+    And I should see a "Select patches" text
     And I click on "Clone Channel"
     And I should see a "Clone 3 of Test-Channel-x86_64" text
     And I should see a "Channel Clone 3 of Test-Channel-x86_64 cloned from channel Test-Channel-x86_64." text
-    And I should see a "You may now wish to clone the errata associated with Test-Channel-x86_64." text
+    And I should see a "You may now wish to clone the patches associated with Test-Channel-x86_64." text
     And I check the row with the "hoag-dummy-7890" link
     And I check the row with the "virgo-dummy-3456" link
-    And I click on "Clone Errata"
+    And I click on "Clone Patches"
     And I click on "Confirm"
     Then I should see a "CL-hoag-dummy-7890" link
     And I should see a "CL-virgo-dummy-3456" link
 
-  Scenario: check new errata exists
-    Given I am on the errata page
+  Scenario: check new patches exists
+    Given I am on the patches page
     When I follow "All" in the left menu
     And I select "500" from "1154021400_PAGE_SIZE_LABEL"
     Then I should see a "CL-hoag-dummy-7890" link
@@ -73,8 +73,8 @@ Feature: Clone a Channel
     And I should see a "CL-milkyway-dummy-2345" link
     And I should see a "CL-andromeda-dummy-6789" link
 
-  Scenario: check CL-hoag-dummy-7890 errata
-    Given I am on the errata page
+  Scenario: check CL-hoag-dummy-7890 patches
+    Given I am on the patches page
     When I follow "All" in the left menu
     And I select "500" from "1154021400_PAGE_SIZE_LABEL"
     And I follow "CL-hoag-dummy-7890"
@@ -82,8 +82,8 @@ Feature: Clone a Channel
     And I should see a "mcalmer" text
     And I should see a "https://bugzilla.suse.com/show_bug.cgi?id=704608" link
 
-  Scenario: check CM-virgo-dummy-3456 errata
-    Given I am on the errata page
+  Scenario: check CM-virgo-dummy-3456 patches
+    Given I am on the patches page
     When I follow "All" in the left menu
     And I select "500" from "1154021400_PAGE_SIZE_LABEL"
     And I follow "CL-virgo-dummy-3456"

--- a/features/create_repository.feature
+++ b/features/create_repository.feature
@@ -7,12 +7,10 @@ Feature: Adding repository to a channel
   I want to add a repository
   And I want to add this repository to the base channel
 
-  Background:
-  Given I am authorized as "testing" with password "testing"
-  And I follow "Home" in the left menu
-  And I follow "Channels"
-
   Scenario: Adding Test-Repository-x86_64 repository
+    Given I am authorized as "testing" with password "testing"
+    And I follow "Home" in the left menu
+    And I follow "Channels"
     When I follow "Manage Software Channels" in the left menu
     And I follow "Manage Repositories" in the left menu
     And I follow "Create Repository"
@@ -23,6 +21,9 @@ Feature: Adding repository to a channel
     And I should see "metadataSigned" as checked
 
   Scenario: Disable Metadata check for Test-Repository-x86_64 repository
+    Given I am authorized as "testing" with password "testing"
+    And I follow "Home" in the left menu
+    And I follow "Channels"
     When I follow "Manage Software Channels" in the left menu
     And I follow "Manage Repositories" in the left menu
     And I follow "Test-Repository-x86_64"
@@ -32,6 +33,9 @@ Feature: Adding repository to a channel
     And I should see "metadataSigned" as unchecked
 
   Scenario: Add repository to the x86_64 channel
+    Given I am authorized as "testing" with password "testing"
+    And I follow "Home" in the left menu
+    And I follow "Channels"
     When I follow "Manage Software Channels" in the left menu
     And I follow "Overview" in the left menu
     And I follow "Test-Channel-x86_64"
@@ -41,6 +45,9 @@ Feature: Adding repository to a channel
     Then I should see a "Test-Channel-x86_64 repository information was successfully updated" text
 
   Scenario: Sync the repository in the x86_64 channel
+    Given I am authorized as "testing" with password "testing"
+    And I follow "Home" in the left menu
+    And I follow "Channels"
     When I follow "Manage Software Channels" in the left menu
     And I follow "Manage Repositories" in the left menu
     And I follow "Overview" in the left menu
@@ -51,6 +58,9 @@ Feature: Adding repository to a channel
     Then I should see a "Repository sync scheduled for Test-Channel-x86_64." text
 
   Scenario: Adding Test-Repository-i586 repository
+    Given I am authorized as "testing" with password "testing"
+    And I follow "Home" in the left menu
+    And I follow "Channels"
     When I follow "Manage Software Channels" in the left menu
     And I follow "Manage Repositories" in the left menu
     And I follow "Create Repository"
@@ -61,6 +71,9 @@ Feature: Adding repository to a channel
     Then I should see a "Repository created successfully" text
 
   Scenario: Add repository to the i586 channel
+    Given I am authorized as "testing" with password "testing"
+    And I follow "Home" in the left menu
+    And I follow "Channels"
     When I follow "Manage Software Channels" in the left menu
     And I follow "Overview" in the left menu
     And I follow "Test-Channel-i586"
@@ -70,6 +83,9 @@ Feature: Adding repository to a channel
     Then I should see a "Test-Channel-i586 repository information was successfully updated" text
 
   Scenario: Sync the repository in the i586 channel
+    Given I am authorized as "testing" with password "testing"
+    And I follow "Home" in the left menu
+    And I follow "Channels"
     When I follow "Manage Software Channels" in the left menu
     And I follow "Overview" in the left menu
     And I follow "Test-Channel-i586"
@@ -77,3 +93,25 @@ Feature: Adding repository to a channel
     And I follow "Sync"
     When I click on "Sync Now"
     Then I should see a "Repository sync scheduled for Test-Channel-i586." text
+
+  Scenario: schedule "errata-cache" refresh
+    Given I am authorized as "admin" with password "admin"
+    When I follow "Admin"
+    And I follow "Task Schedules"
+    And I follow "Task Schedules"
+    And I follow "errata-cache-default"
+    And I follow "errata-cache-bunch"
+    And I click on "Single Run Schedule"
+    Then I should see a "bunch was scheduled" text
+    And I wait for "5" seconds
+
+  Scenario: schedule "channel-repodata" refresh
+    Given I am authorized as "admin" with password "admin"
+    When I follow "Admin"
+    And I follow "Task Schedules"
+    And I follow "Task Schedules"
+    And I follow "channel-repodata-default"
+    And I follow "channel-repodata-bunch"
+    And I click on "Single Run Schedule"
+    Then I should see a "bunch was scheduled" text
+    And I wait for "5" seconds

--- a/features/distro_cobbler.feature
+++ b/features/distro_cobbler.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2017 Novell, Inc.
 # Licensed under the terms of the MIT license.
 
-Feature: cobbler and distro Kickstart
+Feature: cobbler and distro Autoinstallation
 
   Background:
     Given I am authorized
@@ -18,7 +18,7 @@ Feature: cobbler and distro Kickstart
     And distro "testdistro" exists
     Then create profile "testprofile" as user "testing" with password "testing"
 
-  Scenario: Check cobbler created distro and profile Systems => Kickstart => Profiles
+  Scenario: Check cobbler created distro and profile Systems => Autoinstallation => Profiles
     When I follow "Autoinstallation" in the left menu
     And I follow "Profiles" in the left menu
     Then I should see a "testprofile" text
@@ -41,17 +41,17 @@ Feature: cobbler and distro Kickstart
   Scenario: create a profile with the UI (requires a base channel)
     When I follow "Autoinstallation" in the left menu
     And I follow "Profiles" in the left menu
-    And I follow "Create Kickstart Profile"
+    And I follow "Create Autoinstallation Profile"
     When I enter "fedora_kickstart_profile" as "kickstartLabel"
     And I click on "Next"
     And I click on "Next"
     And I enter "linux" as "rootPassword"
     And I enter "linux" as "rootPasswordConfirm"
     And I click on "Finish"
-    Then I should see a "Kickstart: fedora_kickstart_profile" text
-    And I should see a "Kickstart Details" link
+    Then I should see a "Autoinstallation: fedora_kickstart_profile" text
+    And I should see a "Autoinstallation Details" link
 
-  Scenario: test Upload Kickstart/Autoyast File page
+  Scenario: test Upload Autoinstallation/Autoyast File page
     When I am on the Create Autoinstallation Profile page
     And I follow "Profiles" in the left menu
     Then I should see a "Distributions" text
@@ -59,12 +59,12 @@ Feature: cobbler and distro Kickstart
   Scenario: upload a profile with the UI (requires a base channel)
     When I follow "Autoinstallation" in the left menu
     And I follow "Profiles" in the left menu
-    And I follow "Upload Kickstart File"
+    And I follow "Upload Autoinstallation/Autoyast File"
     When I enter "fedora_kickstart_profile_upload" as "kickstartLabel"
     And I attach the file "/example.ks" to "fileUpload"
     And I click on "Create"
-    Then I should see a "Kickstart: fedora_kickstart_profile_upload" text
-    And I should see a "Kickstart Details" text
+    Then I should see a "Autoinstallation: fedora_kickstart_profile_upload" text
+    And I should see a "Autoinstallation Details" text
 
   Scenario: adding a unprovisioned range to a profile (requires fedora_kickstart_profile)
     When I follow "Autoinstallation" in the left menu

--- a/features/install_package_and_errata.feature
+++ b/features/install_package_and_errata.feature
@@ -15,13 +15,13 @@ Feature: Install a package to the client
     Then I should see a "1 package install has been scheduled for" text
     And "hoag-dummy-1.1-2.1" is installed on "client"
 
-  Scenario: Install an erratum to the client
+  Scenario: Install an patch to the client
     Given I am on the Systems overview page of this "sle-client"
     And I follow "Software" in the content area
-    And I follow "Errata" in the content area
+    And I follow "Patches" in the content area
     When I check "virgo-dummy-3456" in the list
-    And I click on "Apply Errata"
+    And I click on "Apply Patches"
     And I click on "Confirm"
     And I run rhn_check on this client
-    Then I should see a "1 errata update has been scheduled for" text
+    Then I should see a "1 patch update has been scheduled for" text
     And "virgo-dummy-2.0-1.1" is installed on "client"

--- a/features/mainpage.feature
+++ b/features/mainpage.feature
@@ -55,7 +55,7 @@ Feature: Explore the main landing page
     Given I am authorized
     Then I should see a "Overview" link
     And I should see a "Systems" link
-    And I should see a "Errata" link
+    And I should see a "Patches" link
     And I should see a "Channels" link
     And I should see a "Configuration" link
     And I should see a "Schedule" link
@@ -75,6 +75,6 @@ Feature: Explore the main landing page
     And I should see a "Inactive Systems" text
     And I should see a "Most Critical Systems" text
     And I should see a "Recently Scheduled Actions" text
-    And I should see a "Relevant Security Errata" text
+    And I should see a "Relevant Security Patches" text
     And I should see a "System Group Name" text
     And I should see a "Recently Registered Systems" text

--- a/features/patches_page.feature
+++ b/features/patches_page.feature
@@ -1,26 +1,26 @@
 # Copyright (c) 2017 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Explore the Errata page
-  In Order to validate completeness of the errata page
+Feature: Explore the Patches page
+  In Order to validate completeness of the patches page
   As a authorized user
   I want to see all the texts and links
 
   Scenario: Completeness of the Patches left menu
-    Given I am on the errata page
-    Then I should see a "Errata Relevant to Your Systems" text
+    Given I am on the patches page
+    Then I should see a "Patches Relevant to Your Systems" text
     And I should see a "Relevant" link in the left menu
     And I should see a "All" link in the left menu
     And I should see a "Advanced Search" link in the left menu
-    And I should see a "Manage Errata" link in the left menu
-    And I should see a "Clone Errata" link in the left menu
-    And I should see a "Bugfix Errata" link
-    And I should see a "Enhancement Errata" link
-    And I should see a "Security Errata" link
+    And I should see a "Manage Patches" link in the left menu
+    And I should see a "Clone Patches" link in the left menu
+    And I should see a "Bugfix Patches" link
+    And I should see a "Enhancement Patches" link
+    And I should see a "Security Patches" link
     And I should see a Sign Out link
 
-  Scenario: Create new bugfix Patch with bnc URL
-    Given I am on the errata page
+  Scenario: Create new bugfix patch with bnc URL
+    Given I am on the patches page
     And I follow "Manage Patches" in the left menu
     And I follow "Published" in the left menu
     And I follow "Create Patch"
@@ -38,14 +38,14 @@ Feature: Explore the Errata page
     And I enter "Test Reference" as "refersTo"
     And I enter "Test Note" as "notes"
     And I click on "Create Patch"
-    Then I should see a "Errata Test Advisory-1 created." text
+    Then I should see a "Patch Test Advisory-1 created." text
 
   Scenario: Create new enhancement patch with no bnc URL
-    Given I am on the errata page
+    Given I am on the patches page
     And I follow "Manage Patches" in the left menu
     And I follow "Published" in the left menu
     And I follow "Create Patch"
-    When I enter "Enhancement Erratum" as "synopsis"
+    When I enter "Enhancement Patch" as "synopsis"
     And I enter "Enhancement Advisory" as "advisoryName"
     And I select "Product Enhancement Advisory" from "advisoryType"
     And I enter "Enhancement Product" as "product"
@@ -58,29 +58,29 @@ Feature: Explore the Errata page
     And I enter "Enhancement Reference" as "refersTo"
     And I enter "Enhancement Note" as "notes"
     And I click on "Create Patch"
-    Then I should see a "Errata Enhancement Advisory-1 created." text
+    Then I should see a "Patch Enhancement Advisory-1 created." text
 
   Scenario: Delete enhancement patch
-    Given I am on the errata page
+    Given I am on the patches page
     And I follow "Manage Patches" in the left menu
     And I follow "Unpublished" in the left menu
-    And I check "Enhancement Advisory" erratum
-    And I click on "Delete Patch"
+    And I check "Enhancement Advisory" patch
+    And I click on "Delete Patches"
     And I click on "Confirm"
-    Then I should see a "Successfully deleted 1 errata." text
+    Then I should see a "Successfully deleted 1 patches." text
 
   Scenario: Publish patch called "Test advisory"
-    Given I am on the errata page
+    Given I am on the patches page
     And I follow "Manage Patches" in the left menu
     And I follow "Unpublished" in the left menu
     And I follow "Test Advisory"
-    And I click on "Publish Errata"
+    And I click on "Publish Patch"
     And I check test channel
-    And I click on "Publish Errata"
+    And I click on "Publish Patch"
     Then I should see a "All Types" text
 
   Scenario: Verify patch presence in webui(bugfixing patch)
-    Given I am on the errata page
+    Given I am on the patches page
     And I follow "All" in the left menu
     And I follow "Bugfix Patches" in the content area
     And I enter "Test Patch" in the css "input[placeholder='Filter by Synopsis: ']"
@@ -98,19 +98,19 @@ Feature: Explore the Errata page
     And I should see a "Test Note" text
 
   Scenario: Assert that Patch is now in Test-base channel
-    Given I am on the errata page
+    Given I am on the patches page
     And I follow "Software" in the left menu
     And I follow "Channels" in the left menu
     And I follow "Channels > All" in the left menu
     And I follow "Test Base Channel"
-    And I follow "Errata" in the content area
+    And I follow "Patches" in the content area
     Then I should see a "Test Patch" text
 
-  Scenario: Delete the test advisory patch
-    Given I am on the errata page
+  Scenario: Delete patch
+    Given I am on the patches page
     And I follow "Manage Patches" in the left menu
     And I follow "Published" in the left menu
-    And I check "Test Advisory" erratum
-    And I click on "Delete Patch"
+    And I check "Test Advisory" patch
+    And I click on "Delete Patches"
     And I click on "Confirm"
-    Then I should see a "Successfully deleted 1 errata." text
+    Then I should see a "Successfully deleted 1 patches." text

--- a/features/register_client.feature
+++ b/features/register_client.feature
@@ -28,11 +28,11 @@ Feature: Register a client
     And I should see a "OS: sles-release" text
     And I should see a "Release: 12.2" text
 
-  Scenario: check tab links "Software" => "Errata"
+  Scenario: check tab links "Software" => "Patches"
     Given I am on the Systems overview page of this "sle-client"
     When I follow "Software" in the content area
-    And I follow "Errata" in the content area
-    Then I should see a "Relevant Errata" text
+    And I follow "Patches" in the content area
+    Then I should see a "Relevant Patches" text
     And I should see a "Show" button
     And I should see a "Test update for virgo-dummy" text
     And I should see an update in the list

--- a/features/salt_install_package.feature
+++ b/features/salt_install_package.feature
@@ -6,13 +6,13 @@ Feature: Install a patch the client via salt through the UI
    Scenario: wait for taskomatic finished required jobs
     Given Patches are visible for the registered client
 
-   Scenario: Install an erratum to the minion
+   Scenario: Install an patch to the minion
     Given I am on the Systems overview page of this "sle-minion"
     And I follow "Software" in the content area
-    And I follow "Errata" in the content area
+    And I follow "Patches" in the content area
     When I check "virgo-dummy-3456" in the list
-    And I click on "Apply Errata"
+    And I click on "Apply Patches"
     And I click on "Confirm"
     And I wait for "5" seconds
-    Then I should see a "1 errata update has been scheduled for" text
+    Then I should see a "1 patch update has been scheduled for" text
     And I wait for "virgo-dummy-2.0-1.1" to be installed on this "sle-minion"

--- a/features/salt_install_with_staging.feature
+++ b/features/salt_install_with_staging.feature
@@ -40,12 +40,12 @@ Feature: Install a package on the minion with staging enabled
     And I follow "Software" in the content area
     And I click on "Update Package List"
     And I wait for "30" seconds
-    And I follow "Errata" in the content area
+    And I follow "Patches" in the content area
     When I check "virgo-dummy-3456" in the list
-    And I click on "Apply Errata"
+    And I click on "Apply Patches"
     And I pick 2 minutes from now as schedule time
     And I click on "Confirm"
-    Then I should see a "1 errata update has been scheduled for" text
+    Then I should see a "1 patch update has been scheduled for" text
     And I wait until the package "virgo-dummy-2.0-1.1.noarch" has been cached on this "sle-minion"
     And I wait for "virgo-dummy-2.0-1.1" to be installed on this "sle-minion"
     Then I disable repository "Devel_Galaxy_BuildRepo" on this "sle-minion"

--- a/features/step_definitions/content_steps.rb
+++ b/features/step_definitions/content_steps.rb
@@ -18,9 +18,9 @@ end
 # Test for a text in the whole page
 #
 Then(/^I should see a "([^"]*)" text$/) do |arg1|
-  unless page.has_content?(debrand_string(arg1))
+  unless page.has_content?(arg1)
     sleep 25
-    fail unless page.has_content?(debrand_string(arg1))
+    fail unless page.has_content?(arg1)
   end
 end
 #
@@ -28,21 +28,21 @@ end
 #
 Then(/^I should see "([^"]*)" in the textarea$/) do |arg1|
   within('textarea') do
-    fail unless page.has_content?(debrand_string(arg1))
+    fail unless page.has_content?(arg1)
   end
 end
 
 Then(/^I should see "([^"]*)" loaded in the textarea$/) do |arg1|
-  fail unless first('textarea').value.include?(debrand_string(arg1))
+  fail unless first('textarea').value.include?(arg1)
 end
 
 #
 # Test for a text in the whole page using regexp
 #
 Then(/^I should see a text like "([^"]*)"$/) do |arg1|
-  unless page.has_content?(Regexp.new("#{debrand_string(arg1)}"))
+  unless page.has_content?(Regexp.new("#{arg1}"))
     sleep 10
-    fail unless page.has_content?(Regexp.new("#{debrand_string(arg1)}"))
+    fail unless page.has_content?(Regexp.new("#{arg1}"))
   end
 end
 
@@ -60,11 +60,11 @@ end
 # Test for a visible link in the whole page
 #
 Then(/^I should see a "([^"]*)" link$/) do |arg1|
-  link = first(:link, debrand_string(arg1))
+  link = first(:link, arg1)
   if link.nil?
     sleep 40
     $stderr.puts "ERROR - try again"
-    fail unless first(:link, debrand_string(arg1)).visible?
+    fail unless first(:link, arg1).visible?
   else
     fail unless link.visible?
   end
@@ -93,30 +93,30 @@ end
 #
 Then(/^I should see a "([^"]*)" link in element "([^"]*)"$/) do |arg1, arg2|
   within(:xpath, "//div[@id=\"#{arg2}\" or @class=\"#{arg2}\"]") do
-    fail unless find_link(debrand_string(arg1)).visible?
+    fail unless find_link(arg1).visible?
   end
 end
 
 Then(/^I should not see a "([^"]*)" link in element "([^"]*)"$/) do |arg1, arg2|
   within(:xpath, "//div[@id=\"#{arg2}\" or @class=\"#{arg2}\"]") do
-      fail unless has_no_link?(debrand_string(arg1))
+      fail unless has_no_link?(arg1)
   end
 end
 
 Then(/^I should see a "([^"]*)" text in element "([^"]*)"$/) do |arg1, arg2|
   within(:xpath, "//div[@id=\"#{arg2}\" or @class=\"#{arg2}\"]") do
-    fail unless has_content?(debrand_string(arg1))
+    fail unless has_content?(arg1)
   end
 end
 
 Then(/^I should see a "([^"]*)" or "([^"]*)" text in element "([^"]*)"$/) do |arg1, arg2, arg3|
   within(:xpath, "//div[@id=\"#{arg3}\" or @class=\"#{arg3}\"]") do
-    fail if !has_content?(debrand_string(arg1)) && !has_content?(debrand_string(arg2))
+    fail if !has_content?(arg1) && !has_content?(arg2)
   end
 end
 
 Then(/^I should see a "([^"]*)" link in "([^"]*)" "([^"]*)"$/) do |arg1, arg2, arg3|
-  fail unless page.has_xpath?("//#{arg2}[@id='#{arg3}' or @class='#{arg3}']/a[text()='#{debrand_string(arg1)}']")
+  fail unless page.has_xpath?("//#{arg2}[@id='#{arg3}' or @class='#{arg3}']/a[text()='#{arg1}']")
 end
 
 Then(/^I should see a "([^"]*)" link in the table (.*) column$/) do |link, column|

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -93,10 +93,10 @@ end
 #
 When(/^I click on "([^"]*)"$/) do |arg1|
   begin
-    click_button debrand_string(arg1), :match => :first
+    click_button arg1, :match => :first
   rescue
     sleep 10
-    click_button debrand_string(arg1), :match => :first
+    click_button arg1, :match => :first
   end
 end
 #
@@ -112,17 +112,17 @@ end
 #
 When(/^I follow "([^"]*)"$/) do |text|
   begin
-    click_link(debrand_string(text))
+    click_link(text)
   rescue
     sleep 10
-    click_link(debrand_string(text))
+    click_link(text)
   end
 end
 #
 # Click on the first link
 #
 When(/^I follow first "([^"]*)"$/) do |text|
-  click_link(debrand_string(text), :match => :first)
+  click_link(text, :match => :first)
 end
 
 #
@@ -331,14 +331,14 @@ When(/^I go to the configuration page$/) do
   find_link("Configuration").click
 end
 
-Given(/^I am on the errata page$/) do
+Given(/^I am on the patches page$/) do
   step %(I am authorized)
   visit("https://#{$server_fullhostname}/rhn/errata/RelevantErrata.do")
 end
 
-Given(/^I am on the "([^"]*)" errata Details page$/) do |arg1|
+Given(/^I am on the "([^"]*)" patches Details page$/) do |arg1|
   steps %(
-    Given I am on the errata page
+    Given I am on the patches page
     And I follow "All" in the left menu
     And I follow "#{arg1}"
     )
@@ -349,7 +349,7 @@ Then(/^I should see an update in the list$/) do
 end
 
 Given(/^Patches are visible for the registered client$/) do
-  step "I am on the errata page"
+  step "I am on the patches page"
   for c in 0..20
     begin
       step "I should see an update in the list"
@@ -366,7 +366,7 @@ When(/^I check test channel$/) do
   step %(I check "Test Base Channel" in the list)
 end
 
-When(/^I check "([^"]*)" erratum$/) do |arg1|
+When(/^I check "([^"]*)" patch$/) do |arg1|
   step %(I check "#{arg1}" in the list)
 end
 
@@ -399,7 +399,7 @@ Then(/^I try to reload page until contains "([^"]*)" text$/) do |arg1|
   begin
     Timeout.timeout(DEFAULT_TIMEOUT) do
       loop do
-        if page.has_content?(debrand_string(arg1))
+        if page.has_content?(arg1)
           found = true
           break
         end

--- a/features/step_definitions/register_client_steps.rb
+++ b/features/step_definitions/register_client_steps.rb
@@ -42,7 +42,7 @@ end
 
 When(/^I wait for the data update$/) do
   for c in 0..6
-    if page.has_content?(debrand_string("Software Updates Available"))
+    if page.has_content?("Software Updates Available")
       break
     end
     sleep 30

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -447,7 +447,7 @@ Then(/^I click on the css "(.*)" until page does not contain "([^"]*)" text$/) d
   begin
     Timeout.timeout(30) do
       loop do
-        unless page.has_content?(debrand_string(arg1))
+        unless page.has_content?(arg1)
           not_found = true
           break
         end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -52,6 +52,8 @@ def debrand_string(str)
         when "Step 1: Create Kickstart Profile" then str
         when "Create Kickstart Profile" then str
         when "Test Erratum" then str
+        when "errata-cache-default" then str
+        when "errata-cache-bunch" then str
         # replacement exceptions
         when "Create Kickstart Distribution" then "Create Autoinstallable Distribution"
         when "Upload Kickstart File" then "Upload Kickstart/Autoyast File"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -41,42 +41,6 @@ def current_url
   driver.current_url
 end
 
-def debrand_string(str)
-  case BRANDING
-    when 'suse'
-      case str
-        # do not replace
-        when "Update Kickstart" then str
-        when "Kickstart Snippets" then str
-        when "Create a New Kickstart Profile" then str
-        when "Step 1: Create Kickstart Profile" then str
-        when "Create Kickstart Profile" then str
-        when "Test Erratum" then str
-        when "errata-cache-default" then str
-        when "errata-cache-bunch" then str
-        # replacement exceptions
-        when "Create Kickstart Distribution" then "Create Autoinstallable Distribution"
-        when "Upload Kickstart File" then "Upload Kickstart/Autoyast File"
-        when "Upload a New Kickstart File" then "Upload a New Kickstart/AutoYaST File"
-        when "RHN Reference Guide" then "Reference Guide"
-        when "Create Errata" then "Create Patch"
-        when "Publish Errata" then "Publish Patch"
-        # generic regex replace
-        when /.*kickstartable.*/ then str.gsub(/kickstartable/, 'autoinstallable')
-        when /.*Kickstartable.*/ then str.gsub(/Kickstartable/, 'Autoinstallable')
-        when /.*Kickstart.*/ then str.gsub(/Kickstart/, 'Autoinstallation')
-        when /Errata .* created./ then str.sub(/Errata/, 'Patch')
-        when /.*errata update.*/ then str.gsub(/errata update/, 'patch update')
-        when /.*Erratum.*/ then str.gsub(/Erratum/, 'Patch')
-        when /.*erratum.*/ then str.gsub(/erratum/, 'patch')
-        when /.*Errata.*/ then str.gsub(/Errata/, 'Patches')
-        when /.*errata.*/ then str.gsub(/errata/, 'patches')
-        else str
-      end
-    else str
-  end
-end
-
 # may be non url was given
 if host.include?("//")
   raise "TESTHOST must be the FQDN only"

--- a/features/systems_needing_reboot.feature
+++ b/features/systems_needing_reboot.feature
@@ -20,12 +20,12 @@ Feature: Reboot required after patch
     Given I am on the Systems overview page of this "sle-client"
     Then I should not see a "The system requires a reboot" text
 
-  Scenario: Display Reboot Required after installing an Errata
+  Scenario: Display Reboot Required after installing an Patches
     Given I am on the Systems overview page of this "sle-client"
     And I follow "Software" in the content area
-    And I follow "Errata" in the content area
+    And I follow "Patches" in the content area
     When I check "andromeda-dummy-6789" in the list
-    And I click on "Apply Errata"
+    And I click on "Apply Patches"
     And I click on "Confirm"
     And I run rhn_check on this client
     And I follow "Overview" in the left menu

--- a/features/systemspage.feature
+++ b/features/systemspage.feature
@@ -23,7 +23,7 @@ Feature: Explore the main landing page
     And I should see a "Activation Keys" link in the left menu
     And I should see a "Stored Profiles" link in the left menu
     And I should see a "Custom System Info" link in the left menu
-    And I should see a "Kickstart" link in the left menu
+    And I should see a "Autoinstallation" link in the left menu
     And I should see a "View System Groups" link
     And I should see a "Software Crashes" link in the left menu
     And I should see a "Download CSV" link
@@ -158,7 +158,7 @@ Feature: Explore the main landing page
     And I should see a "Task Log" link in the left menu
     And I should see a "Overview" link in the content area
     And I should see a "Systems" link in the content area
-    And I should see a "Errata" link in the content area
+    And I should see a "Patches" link in the content area
     And I should see a "Packages" link in the content area
     And I should see a "Groups" link in the content area
     And I should see a "Channels" link in the content area
@@ -196,18 +196,18 @@ Feature: Explore the main landing page
     And I should see a "Distributions" link in the left menu
     And I should see a "File Preservation" link in the left menu
     And I should see a "Autoinstallation Snippets" link in the left menu
-    And I should see a "Create Kickstart Profile" link
-    And I should see a "Upload Kickstart File" link
-    And I should see a "View a List of Kickstart Profiles" link
-    And I should see a "Create a New Kickstart Profile" link
-    And I should see a "Upload a New Kickstart File" link
+    And I should see a "Create Autoinstallation Profile" link
+    And I should see a "Upload Autoinstallation/Autoyast File" link
+    And I should see a "View a List of Autoinstallation Profiles" link
+    And I should see a "Create a New Autoinstallation Profile" link
+    And I should see a "Upload a New Autoinstallation/AutoYaST File" link
 
-  Scenario: Check sidebar link destination for Systems => Kickstart => Profiles
+  Scenario: Check sidebar link destination for Systems => Autoinstallation => Profiles
     When I follow "Autoinstallation" in the left menu
     And I follow "Profiles" in the left menu
-    Then I should see a "Kickstart Profiles" text
-    And I should see a "Create Kickstart Profile" link
-    And I should see a "Upload Kickstart File" link
+    Then I should see a "Autoinstallation Profiles" text
+    And I should see a "Create Autoinstallation Profile" link
+    And I should see a "Upload Autoinstallation/Autoyast File" link
 
   Scenario: Check sidebar link destination for Systems => Autoinstallation => Unprovisioned
     When I follow "Autoinstallation" in the left menu
@@ -215,29 +215,29 @@ Feature: Explore the main landing page
     Then I should see a "Unprovisioned Autoinstallation By IP" text
     And I should see a "No Ip Ranges Found" text
 
-  Scenario: Check sidebar link destination for Systems => Kickstart => GPG and SSL Keys
+  Scenario: Check sidebar link destination for Systems => Autoinstallation => GPG and SSL Keys
     When I follow "Autoinstallation" in the left menu
     And I follow "GPG and SSL Keys" in the left menu
     Then I should see a "GPG Public Keys and SSL Certificates" text
     And I should see a "Create Stored Key/Cert" link
-    And I should see a "RHN Reference Guide" link
+    And I should see a "Reference Guide" link
     And I should see a "RHN-ORG-TRUSTED-SSL-CERT" link
 
-  Scenario: Check sidebar link destination for Systems => Kickstart => Distributions
+  Scenario: Check sidebar link destination for Systems => Autoinstallation => Distributions
     When I follow "Autoinstallation" in the left menu
     And I follow "Distributions" in the left menu
-    Then I should see a "Kickstartable Distributions" text
-    And I should see a "No kickstartable distributions available." text
+    Then I should see a "Autoinstallable Distributions" text
+    And I should see a "No autoinstallable distributions available." text
     And I should see a "Create Distribution" link
 
-  Scenario: Check sidebar link destination for Systems => Kickstart => File Preservation
+  Scenario: Check sidebar link destination for Systems => Autoinstallation => File Preservation
     When I follow "Autoinstallation" in the left menu
     And I follow "File Preservation" in the left menu
     Then I should see a "File Preservation" text
-    And I should see a "RHN Reference Guide" link
+    And I should see a "Reference Guide" link
     And I should see a "Create File Preservation List" link
 
-  Scenario: Check sidebar link destination for Systems => Kickstart => Kickstart Snippets
+  Scenario: Check sidebar link destination for Systems => Autoinstallation => Autoinstallation Snippets
     When I follow "Autoinstallation" in the left menu
     And I follow "Autoinstallation Snippets" in the left menu
     Then I should see a "Autoinstallation Snippets" text
@@ -247,23 +247,23 @@ Feature: Explore the main landing page
     And I should see a "Custom Snippets" link in the content area
     And I should see a "All Snippets" link in the content area
 
-  Scenario: Check "Create Kickstart Profile" page Systems => Kickstart => Profiles => Create Kickstart Profile
+  Scenario: Check "Create Autoinstallation Profile" page Systems => Autoinstallation => Profiles => Create Autoinstallation Profile
     When I follow "Autoinstallation" in the left menu
     And I follow "Profiles" in the left menu
-    And I follow "Create Kickstart Profile"
-    Then I should see a "Step 1: Create Kickstart Profile" text
+    And I follow "Create Autoinstallation Profile"
+    Then I should see a "Step 1: Create Autoinstallation Profile" text
 
-  Scenario: Check "Upload Kickstart File" page Systems => Kickstart => Profiles => Upload Kickstart File
+  Scenario: Check "Upload Autoinstallation/Autoyast File" page Systems => Autoinstallation => Profiles => Upload Autoinstallation/Autoyast File
     When I follow "Autoinstallation" in the left menu
     And I follow "Profiles" in the left menu
-    And I follow "Upload Kickstart File"
+    And I follow "Upload Autoinstallation/Autoyast File"
     Then I should see a "Create Autoinstallation Profile" text
     And I should see a "File Contents:" text
-    And I should see a "Kickstart Details" text
+    And I should see a "Autoinstallation Details" text
 
-  Scenario: Check "create kickstart distribution" page Systems => Kickstart => Distributions => create new kickstart distribution
+  Scenario: Check "create kickstart distribution" page Systems => Autoinstallation => Distributions => create new kickstart distribution
     When I follow "Autoinstallation" in the left menu
     And I follow "Distributions" in the left menu
     And I follow "Create Distribution"
-    Then I should see a "Create Kickstart Distribution" text
+    Then I should see a "Create Autoinstallation Distribution" text
     And I should see a "Distribution Label" text


### PR DESCRIPTION
Currently, seems `hoag-dummy` package installation is failing for `ssh-minion` because `errata-cache` and `channel-repodata` have not been executed yet (they run automatically every minute)

This PR will explicitly schedule these tasks after syncing repository.

As a gift, this PR gets rid of `debrand_string` helper as discussed on #259 