### PR TITLE
Modify smdba test to work with postgresql94 as well as with postgresql96

### DIFF
--- a/features/smdba.feature
+++ b/features/smdba.feature
@@ -44,7 +44,7 @@ Feature: smdba database helper tool
   Scenario: Check database utilities
     Given a postgresql database is running
     When I issue command "smdba space-overview"
-    Then I find tablespaces "susemanager" and "postgres"
+    Then I find tablespaces "susemanager" and "template0"
     When I issue command "smdba space-reclaim"
     Then I find core examination is "finished", database analysis is "done" and space reclamation is "done"
     When I issue command "smdba space-tables"


### PR DESCRIPTION
With new postgresql version, tablespace "postgres" seems to have been renamed to "template1". So modify test to work on both versions (check for template0 and susemanager).