### PR TITLE
disable test for changing wal_level in postgresql

### DIFF
--- a/features/smdba.feature
+++ b/features/smdba.feature
@@ -26,20 +26,20 @@ Feature: smdba database helper tool
     And when I issue command "smdba db-status"
     Then I want to see if the database is "online"
 
-  Scenario: Check system check of the database sets optimal configuration
-    Given a postgresql database is running
-    When I stop the database with the command "smdba db-stop"
-    And when I configure "/var/lib/pgsql/data/postgresql.conf" parameter "wal_level" to "hot_standby"
-    Then I start database with the command "smdba db-start"
-    And when I issue command "smdba db-status"
-    Then I want to see if the database is "online"
-    And when I check internally configuration for "wal_level" option
-    Then I expect to see the configuration is set to "hot_standby"
-    And I issue command "smdba system-check"
-    And when I stop the database with the command "smdba db-stop"
-    And I start database with the command "smdba db-start"
-    And when I check internally configuration for "wal_level" option
-    Then I expect to see the configuration is set to "archive"
+#  Scenario: Check system check of the database sets optimal configuration
+#    Given a postgresql database is running
+#    When I stop the database with the command "smdba db-stop"
+#    And when I configure "/var/lib/pgsql/data/postgresql.conf" parameter "wal_level" to "hot_standby"
+#    Then I start database with the command "smdba db-start"
+#    And when I issue command "smdba db-status"
+#    Then I want to see if the database is "online"
+#    And when I check internally configuration for "wal_level" option
+#    Then I expect to see the configuration is set to "hot_standby"
+#    And I issue command "smdba system-check"
+#    And when I stop the database with the command "smdba db-stop"
+#    And I start database with the command "smdba db-start"
+#    And when I check internally configuration for "wal_level" option
+#    Then I expect to see the configuration is set to "archive"
 
   Scenario: Check database utilities
     Given a postgresql database is running


### PR DESCRIPTION
With postgresql96, this test is pointless since both archive and hot_standby are being mapped to "replica" now. Also this value gets set at initial configuration time and should never get changed later on. After completely switching to postgresql96, we can still re-activate the test, but checking for change in output is pointless as it will always report "replica". We could use "minimal" for testing, though. See also:

https://www.postgresql.org/docs/9.5/static/runtime-config-wal.html
https://www.postgresql.org/docs/9.6/static/runtime-config-wal.html#GUC-WAL-LEVEL

"In releases prior to 9.6, this parameter also allowed the values archive and hot_standby. These are still accepted but mapped to replica."