### PR TITLE
Click on CSS button to refresh the page instead manual page refresh

### DIFF
--- a/features/min_salt_install_package.feature
+++ b/features/min_salt_install_package.feature
@@ -11,8 +11,7 @@ Feature: Install a patch the client via salt through the UI
     And I follow "Software" in the content area
     And I follow "List / Remove" in the content area
     And I enter "virgo-dummy" in the css "input[placeholder='Filter by Package Name: ']"
-    And I click on the css "button.spacewalk-button-filter"
-    And I wait until i see "virgo-dummy" text, refreshing the page
+    And I click on the css "button.spacewalk-button-filter" until page does contain "virgo-dummy" text
     When I follow "Admin"
     And I follow "Task Schedules"
     And I follow "errata-cache-default"

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -449,7 +449,7 @@ end
 Then(/^I click on the css "(.*)" until page does not contain "([^"]*)" text$/) do |css, text|
   not_found = false
   begin
-    Timeout.timeout(30) do
+    Timeout.timeout(DEFAULT_TIMEOUT) do
       loop do
         unless page.has_content?(text)
           not_found = true
@@ -467,7 +467,7 @@ end
 Then(/^I click on the css "(.*)" until page does contain "([^"]*)" text$/) do |css, text|
   found = false
   begin
-    Timeout.timeout(30) do
+    Timeout.timeout(DEFAULT_TIMEOUT) do
       loop do
         unless page.has_content?(text)
           found = true

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -446,12 +446,12 @@ Then(/^I manually remove the "([^"]*)" package in the minion$/) do |package|
   $minion.run(cmd, false)
 end
 
-Then(/^I click on the css "(.*)" until page does not contain "([^"]*)" text$/) do |css, arg1|
+Then(/^I click on the css "(.*)" until page does not contain "([^"]*)" text$/) do |css, text|
   not_found = false
   begin
     Timeout.timeout(30) do
       loop do
-        unless page.has_content?(arg1)
+        unless page.has_content?(text)
           not_found = true
           break
         end
@@ -459,17 +459,17 @@ Then(/^I click on the css "(.*)" until page does not contain "([^"]*)" text$/) d
       end
     end
   rescue Timeout::Error
-    raise "'#{arg1}' is still found after several tries"
+    raise "'#{text}' still found after several tries"
   end
   raise unless not_found
 end
 
-Then(/^I click on the css "(.*)" until page does contain "([^"]*)" text$/) do |css, arg1|
+Then(/^I click on the css "(.*)" until page does contain "([^"]*)" text$/) do |css, text|
   found = false
   begin
     Timeout.timeout(30) do
       loop do
-        unless page.has_content?(arg1)
+        unless page.has_content?(text)
           found = true
           break
         end
@@ -477,7 +477,7 @@ Then(/^I click on the css "(.*)" until page does contain "([^"]*)" text$/) do |c
       end
     end
   rescue Timeout::Error
-    raise "'#{arg1}' cannot be found after several tries"
+    raise "'#{text}' cannot be found after several tries"
   end
   raise unless found
 end

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -459,10 +459,29 @@ Then(/^I click on the css "(.*)" until page does not contain "([^"]*)" text$/) d
       end
     end
   rescue Timeout::Error
-    raise "'#{arg1}' cannot be found after several tries"
+    raise "'#{arg1}' is still found after several tries"
   end
   raise unless not_found
 end
+
+Then(/^I click on the css "(.*)" until page does contain "([^"]*)" text$/) do |css, arg1|
+  found = false
+  begin
+    Timeout.timeout(30) do
+      loop do
+        unless page.has_content?(arg1)
+          found = true
+          break
+        end
+        find(css).click
+      end
+    end
+  rescue Timeout::Error
+    raise "'#{arg1}' cannot be found after several tries"
+  end
+  raise unless found
+end
+
 # states catalog
 When(/^I enter the salt state$/) do |multiline|
   within(:xpath, '//section') do


### PR DESCRIPTION
This PR fixes an issue caused due a waiting step which refreshes the page in a wrong way (without keeping the package list filter). 🍰  

These changes will go to `manager31` and `master` branches.