### PR TITLE
Import the gpgkey for installing pkgs

### DIFF
--- a/features/core_min_salt_ssh.feature
+++ b/features/core_min_salt_ssh.feature
@@ -57,6 +57,7 @@ Feature: 1) Bootstrap a new salt host via salt-ssh
     Then I should see a "bunch was scheduled" text
     And I reload the page
     And I reload the page until it does contain a "FINISHED" text in the table first row
+    And I run "zypper -n --gpg-auto-import-keys ref" on "ssh-minion"
 
   Scenario: Install a package for ssh minion
     Given I am authorized as "testing" with password "testing"


### PR DESCRIPTION
is not enough to import via `rpm` the keys. zypper need to be involved.

:panda_face: 