### PR TITLE
Generate bootstrap-repo os_version based dynamically

### DIFF
--- a/features/core_min_bootstrap.feature
+++ b/features/core_min_bootstrap.feature
@@ -3,9 +3,9 @@
 
 Feature: register a salt-minion via bootstrap
 
-  Scenario: Create bootstrap-repo for sle12sp2
+  Scenario: Create bootstrap-repo for a salt client
      Given I am authorized
-     And  I run "mgr-create-bootstrap-repo -c SLE-12-SP2-x86_64" on "server" without error control
+     And I create the "x86_64" bootstrap-repo for "sle-minion" on the server
 
   Scenario: bootstrap a sles minion (it will be deleted after)
      Given I am authorized

--- a/features/step_definitions/command_steps.rb
+++ b/features/step_definitions/command_steps.rb
@@ -395,3 +395,13 @@ And(/^I wait until the package "(.*?)" has been cached on this "(.*?)"$/) do |pk
     end
   end
 end
+
+And(/^I create the "([^"]*)" bootstrap-repo for "([^"]*)" on the server$/) do |arch, target|
+  node = get_target(target)
+  os_version_raw, _code = node.run('grep "VERSION=" /etc/os-release')
+  os_version = os_version_raw.strip.split('=')[1].delete '"'
+  puts 'i should see the os version: ' + os_version
+  command = 'mgr-create-bootstrap-repo -c SLE-' + os_version + '-' + arch
+  puts 'running the command on the server:' + command
+  $server.run(command, false)
+end


### PR DESCRIPTION
Generate the `bootstrap-repo` based on the `os_version` dynamically reading the `os_version` directly from the client.