### PR TITLE
Idempotent test for bootstrapping system via XMLRPC API

### DIFF
--- a/features/min_bootstrap_xmlrpc.feature
+++ b/features/min_bootstrap_xmlrpc.feature
@@ -1,0 +1,66 @@
+# Copyright (c) 2017 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: register a salt-minion via XMLRPC API bootstrap procedure
+
+  Scenario: Setup XMLRPC Bootstrap: Delete sles-minion system profile before XMLRPC bootstrap test
+    Given I am on the Systems overview page of this "sle-minion"
+    When I follow "Delete System"
+    And I should see a "Confirm System Profile Deletion" text
+    And I click on "Delete Profile"
+    Then I should see a "has been deleted" text
+    And I cleanup minion: "sle-minion"
+
+  Scenario: bootstrap a sles minion via XMLRPC API (it will be deleted after)
+    Given I am logged in via XML-RPC/system as user "admin" and password "admin"
+    When I call system.bootstrap() on host "sle-minion" and saltSSH "disabled", a new system should be bootstraped.
+    And I logout from XML-RPC/system.
+
+  Scenario: check new XMLRPC bootstrapped minion in System Overview page
+     Given I am authorized
+     And I go to the minion onboarding page
+     Then I should see a "accepted" text
+     And the salt-master can reach "sle-minion"
+     And I navigate to "rhn/systems/Overview.do" page
+     And I wait until I see the name of "sle-minion", refreshing the page
+     And I wait until onboarding is completed for "sle-minion"
+
+  Scenario: Check contact method of this minion
+    Given I am on the Systems overview page of this "sle-minion"
+    Then I should see a "Default" text
+
+  Scenario: Run a remote command on XMLRPC-bootstrapped sles-minion (salt-service)
+    Given I am authorized as "testing" with password "testing"
+    And I follow "Salt"
+    And I follow "Remote Commands"
+    And I should see a "Remote Commands" text
+    Then I enter command "ls -lha /etc"
+    And I click on preview
+    Then I should see "sle-minion" hostname
+    And I click on run
+    Then I wait for "3" seconds
+    And I expand the results for "sle-minion"
+    Then I should see "SuSE-release" in the command output for "sle-minion"
+
+  Scenario: Check spacecmd system ID of XMLRPC-bootstrapped minion.
+    Given I am on the Systems overview page of this "sle-minion"
+    Then I run spacecmd listevents for sle-minion
+
+  Scenario: Cleanup XMLRPC Bootstrap: Subscribe to base channel
+    Given I am on the Systems overview page of this "sle-minion"
+    When I follow "Software" in the content area
+    Then I follow "Software Channels" in the content area
+    And I select "Test-Channel-x86_64" from "new_base_channel_id"
+    And I click on "Confirm"
+    And I click on "Modify Base Software Channel"
+    And I should see a "System's Base Channel has been updated." text
+
+  Scenario: Bootstraping non-existing system
+    Given I am logged in via XML-RPC/system as user "admin" and password "admin"
+    When I call system.bootstrap() on unknown host, I should get an XMLRPC fault with code -1.
+    And I logout from XML-RPC/system.
+
+  Scenario: Bootstraping salt-ssh system with activation key with Default contact method
+    Given I am logged in via XML-RPC/system as user "admin" and password "admin"
+    When I call system.bootstrap() on a salt minion with saltSSH = true, but with activation key with Default contact method, I should get an XMLRPC fault with code -1.
+    And I logout from XML-RPC/system.

--- a/features/min_ssh_bootstrap_xmlrpc.feature
+++ b/features/min_ssh_bootstrap_xmlrpc.feature
@@ -1,0 +1,50 @@
+Feature: register a salt-ssh system via XMLRPC API bootstrap procedure
+
+  Scenario: Setup XMLRPC Bootstrap: Delete ssh-minion system profile before XMLRPC bootstrap test
+    Given I am on the Systems overview page of this "ssh-minion"
+    When I follow "Delete System"
+    And I should see a "Confirm System Profile Deletion" text
+    And I click on "Delete Profile"
+    Then I should see a "has been deleted" text
+    And I cleanup minion: "ssh-minion"
+
+  Scenario: bootstrap a sles ssh-minion via XMLRPC API (it will be deleted after)
+    Given I am logged in via XML-RPC/system as user "admin" and password "admin"
+    When I call system.bootstrap() on host "ssh-minion" and saltSSH "enabled", a new system should be bootstraped.
+    And I logout from XML-RPC/system.
+
+  Scenario: check new XMLRPC bootstrapped salt-ssh in System Overview page
+     Given I am authorized
+     And I navigate to "rhn/systems/Overview.do" page
+     And I wait until I see the name of "ssh-minion", refreshing the page
+     And I wait until onboarding is completed for "ssh-minion"
+
+  Scenario: Check contact method of this salt-ssh system
+    Given I am on the Systems overview page of this "ssh-minion"
+    Then I should see a "Push via SSH" text
+
+  Scenario: Run a remote command on XMLRPC-bootstrapped ssh-minion
+    Given I am authorized as "testing" with password "testing"
+    And I follow "Salt"
+    And I follow "Remote Commands"
+    And I should see a "Remote Commands" text
+    Then I enter command "ls -lha /etc"
+    And I click on preview
+    Then I should see "ssh-minion" hostname
+    And I click on run
+    Then I wait for "3" seconds
+    And I expand the results for "ssh-minion"
+    Then I should see "SuSE-release" in the command output for "ssh-minion"
+
+  Scenario: Check spacecmd system ID of XMLRPC-bootstrapped ssh-minion.
+    Given I am on the Systems overview page of this "ssh-minion"
+    Then I run spacecmd listevents for ssh-minion
+
+  Scenario: Cleanup XMLRPC Bootstrap: Subscribe ssh-minion to base channel
+    Given I am on the Systems overview page of this "ssh-minion"
+    When I follow "Software" in the content area
+    Then I follow "Software Channels" in the content area
+    And I select "Test-Channel-x86_64" from "new_base_channel_id"
+    And I click on "Confirm"
+    And I click on "Modify Base Software Channel"
+    And I should see a "System's Base Channel has been updated." text

--- a/features/step_definitions/salt_steps.rb
+++ b/features/step_definitions/salt_steps.rb
@@ -864,9 +864,10 @@ And(/^I enter the hostname of "([^"]*)" as hostname$/) do |minion|
   end
 end
 
-Then(/^I run spacecmd listevents for sle-minion$/) do
+Then(/^I run spacecmd listevents for ([^\s]*)$/) do |system|
+  system_fullhostname = get_target_fullhostname(system)
   $server.run('spacecmd -u admin -p admin clear_caches')
-  $server.run("spacecmd -u admin -p admin system_listevents #{$minion_fullhostname}")
+  $server.run("spacecmd -u admin -p admin system_listevents #{system_fullhostname}")
 end
 
 And(/^I cleanup minion: "([^"]*)"$/) do |target|

--- a/features/step_definitions/xmlrpc_common.rb
+++ b/features/step_definitions/xmlrpc_common.rb
@@ -17,6 +17,36 @@ When(/^I call system\.listSystems\(\), I should get a list of them\.$/) do
   rabbit = servers[0]
 end
 
+When(/^I call system\.bootstrap\(\) on host "(.*?)" and saltSSH "(.*?)", \
+a new system should be bootstraped\.$/) do |host, salt_ssh_enabled|
+  salt_ssh = (salt_ssh_enabled == 'enabled')
+
+  result = systest.bootstrapSystem(get_target_fullhostname(host), '', salt_ssh)
+  assert(result == 1, 'Bootstrap return code not equal to 1.')
+end
+
+When(/^I call system\.bootstrap\(\) on unknown host, I should get an XMLRPC fault with code -1.$/) do
+  exception_thrown = false
+  begin
+    systest.bootstrapSystem('imprettysureidontexist', '', false)
+  rescue XMLRPC::FaultException => fault
+    exception_thrown = true
+    assert(fault.faultCode == -1, 'Fault code must be == -1.')
+  end
+  assert(exception_thrown, 'Exception must be thrown for non-existing host.')
+end
+
+When(/^I call system\.bootstrap\(\) on a salt minion with saltSSH = true, \
+but with activation key with Default contact method, I should get an XMLRPC fault with code -1\.$/) do
+  exception_thrown = false
+  begin
+    systest.bootstrapSystem($minion_fullhostname, '1-SUSE-DEV-x86_64', true)
+  rescue XMLRPC::FaultException => fault
+    exception_thrown = true
+    assert(fault.faultCode == -1, 'Fault code must be == -1.')
+  end
+  assert(exception_thrown, 'Exception must be thrown for non-compatible activation keys.')
+end
 When(/^I check a sysinfo by a number of XML\-RPC calls, it just works\. :\-\)$/) do
   assert(rabbit)
   systest.getSysInfo(rabbit)

--- a/features/support/xmlrpc_system.rb
+++ b/features/support/xmlrpc_system.rb
@@ -40,4 +40,26 @@ class XMLRPCSystemTest < XMLRPCBaseTest
     netdevs = [netdev]
     @connection.call('system.createSystemRecord', @sid, sys_name, ks_label, '', '', netdevs)
   end
+
+  # Bootstrap a salt system
+  #
+  # == Parameters:
+  # host::
+  #   hostname or IP address of system to be bootstrapped.
+  # activation_key::
+  #   activation key to be assigned to the system
+  # salt_ssh::
+  #   true if the bootstrapped system should be a salt ssh minion,
+  #   false if it should be regular salt minion
+  #
+  # == Returns:
+  # 1 if the bootstrap procedure was successful.
+  #
+  # == Raises:
+  # XMLRPC fault with faultCode = -1 and descriptive faultString
+  # when there was an error during bootstrap.
+  #
+  def bootstrapSystem(host, activation_key, salt_ssh)
+    @connection.call('system.bootstrap', @sid, host, 22, 'root', 'linux', activation_key, salt_ssh)
+  end
 end

--- a/run_sets/testsuite.yml
+++ b/run_sets/testsuite.yml
@@ -55,6 +55,8 @@
 # * min_ping.feature 
 
 # **** IDEMPOTENT ******
+- features/min_bootstrap_xmlrpc.feature
+- features/min_ssh_bootstrap_xmlrpc.feature
 - features/trad_need_reboot.feature
 - features/trad_ssh_push.feature
 - features/trad_reboot.feature


### PR DESCRIPTION
todo:
- [x] figure out non-working `assert`
- [x] parametrize the port
- [x] ~extract the `sle-minion` real value query somewhere so that it can be reused from my code too~ not needed

- [x] negative tests
- [ ] backport to 31