### PR TITLE
Fixed the problem with the ACE text editor - manager31

### DIFF
--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -166,7 +166,7 @@ When(/^I follow "([^"]*)" on "(.*?)" row$/) do |text, host|
 end
 
 When(/^I enter "(.*?)" in the editor$/) do |arg1|
-  page.execute_script("ace.edit('contents-editor').set_value('#{arg1}')")
+  page.execute_script("ace.edit('contents-editor').insert('#{arg1}')")
 end
 
 When(/^I click Systems, under Systems node$/) do


### PR DESCRIPTION
When creating a new configuration file in a configuration channel, the contents of the file could not be created due to a problem with ACE editor.